### PR TITLE
Add cancel API and status

### DIFF
--- a/server/azure/client.go
+++ b/server/azure/client.go
@@ -137,6 +137,14 @@ func GetDeployment(ctx context.Context, client *armresources.DeploymentsClient, 
 	return model.NewDeploymentResult(details.DeploymentExtended), err
 }
 
+func CancelDeployment(ctx context.Context, client *armresources.DeploymentsClient, name string) error {
+	_, err := client.Cancel(ctx, config.GetEnvironment().RESOURCE_GROUP_NAME, name, &armresources.DeploymentsClientCancelOptions{})
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
 // Delete Azure storage account
 func DeleteStorageAccount(resourceGroupName string, storageAccountName string) error {
 	storageClient, err := armstorage.NewAccountsClient(getAzureInfo().Subscription, getAzureInfo().Credentials, nil)

--- a/server/handler/common.go
+++ b/server/handler/common.go
@@ -3,12 +3,14 @@ package handler
 import (
 	"encoding/json"
 	"net/http"
+	"server/engine"
 
 	log "github.com/sirupsen/logrus"
 	"gorm.io/gorm"
 )
 
 type HandleFuncWithDB func(db *gorm.DB, w http.ResponseWriter, r *http.Request)
+type HandleFuncWithDBAndEngine func(db *gorm.DB, engine *engine.Engine, w http.ResponseWriter, r *http.Request)
 
 func respondJSON(w http.ResponseWriter, status int, payload interface{}) {
 	response, err := json.Marshal(payload)

--- a/server/handler/handler_test.go
+++ b/server/handler/handler_test.go
@@ -130,7 +130,7 @@ func testHttpRoute(t *testing.T, method string, path string, body io.Reader) *ht
 	handler.ConfigureAuthenticationForTesting(true)
 	rec := httptest.NewRecorder()
 
-	installer := api.NewApp(database)
+	installer := api.NewApp(database, nil)
 	installer.GetRouter().ServeHTTP(rec, req)
 
 	return rec

--- a/server/handler/status.go
+++ b/server/handler/status.go
@@ -13,6 +13,7 @@ type InstallationStatus string
 
 const (
 	Deploying InstallationStatus = "DEPLOYING"
+	Canceled  InstallationStatus = "CANCELED"
 	Failed    InstallationStatus = "FAILED"
 	Done      InstallationStatus = "DONE"
 )
@@ -29,6 +30,10 @@ func Status(db *gorm.DB, w http.ResponseWriter, r *http.Request) {
 		latestExecution := getLatestExecution(db, step)
 		if latestExecution.Status == model.PermanentlyFailed {
 			status = Failed
+			break
+		} else if latestExecution.Status == model.Canceled {
+			status = Canceled
+			break
 		} else if latestExecution.Status != model.Succeeded {
 			status = Deploying
 		}

--- a/server/handler/steps.go
+++ b/server/handler/steps.go
@@ -3,6 +3,7 @@ package handler
 import (
 	"net/http"
 
+	"server/engine"
 	"server/model"
 
 	"github.com/gorilla/mux"
@@ -10,8 +11,7 @@ import (
 )
 
 func GetAllSteps(db *gorm.DB, w http.ResponseWriter, r *http.Request) {
-	steps := []model.Step{}
-	db.Model(&model.Step{}).Preload("Executions").Find(&steps)
+	steps := getAllSteps(db)
 	respondJSON(w, http.StatusOK, steps)
 }
 
@@ -23,6 +23,34 @@ func GetStep(db *gorm.DB, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	respondJSON(w, http.StatusOK, step)
+}
+
+func CancelAllSteps(db *gorm.DB, engine *engine.Engine, w http.ResponseWriter, r *http.Request) {
+	steps := getAllSteps(db)
+	// first mark all non executing steps as cancelled
+	for _, aStep := range steps {
+		if len(aStep.Executions) == 0 {
+			db.Save(&model.Execution{
+				Status: model.Canceled,
+				StepID: aStep.ID,
+			})
+		}
+	}
+	// refresh steps
+	steps = getAllSteps(db)
+	// find currently running steps and cancel them
+	for _, aStep := range steps {
+		// check status of last one, there should not be any steps with no executions
+		if aStep.Executions[len(aStep.Executions)-1].Status == model.Started {
+			engine.CancelStep(aStep)
+		}
+	}
+}
+
+func getAllSteps(db *gorm.DB) []model.Step {
+	steps := []model.Step{}
+	db.Model(&model.Step{}).Preload("Executions").Find(&steps)
+	return steps
 }
 
 func getStepOr404(db *gorm.DB, id string, w http.ResponseWriter, r *http.Request) *model.Step {

--- a/server/main.go
+++ b/server/main.go
@@ -25,7 +25,7 @@ func main() {
 
 	engine := engine.NewEngine(exit.Context(), db, deploymentsClient)
 
-	app := api.NewApp(db)
+	app := api.NewApp(db, engine)
 
 	// Start listening for shutdown signal
 	exit.Start()

--- a/server/model/azureModel.go
+++ b/server/model/azureModel.go
@@ -108,10 +108,12 @@ type DeploymentResult struct {
 
 func NewDeploymentResult(response armresources.DeploymentExtended) *DeploymentResult {
 	var status ExecutionStatus
-	if *response.Properties.ProvisioningState == armresources.ProvisioningStateSucceeded {
+	switch *response.Properties.ProvisioningState {
+	case armresources.ProvisioningStateSucceeded:
 		status = Succeeded
-	} else {
-		// Assume anything but Succeeded is failed
+	case armresources.ProvisioningStateCanceled:
+		status = Canceled
+	default:
 		status = Failed
 	}
 	// make sure response outputs are always there, even if empty

--- a/server/model/enum.go
+++ b/server/model/enum.go
@@ -12,6 +12,7 @@ const (
 	Restart           ExecutionStatus = "Restart"
 	Restarted         ExecutionStatus = "Restarted"
 	RestartTimedOut   ExecutionStatus = "RestartTimedOut"
+	Canceled          ExecutionStatus = "Canceled"
 )
 
 // Allow GORM to store the string value of ExecutionStatus


### PR DESCRIPTION
This PR adds API for cancelling the steps gracefully. Instead of terminating the engine, steps are cancelled and the engine will finish its main loop normally.
It will first add cancelled execution to all pending steps (with no executions) and then attempts to cancel deployment of current running steps. 
The engine main loop that goes over the steps has been updated to skip steps that are cancelled.