### PR TITLE
Fix up makefiles for mac

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,3 @@
-export SHELL := /usr/bin/bash
-
 BUILD_DIR := build
 INSTALLER_SERVER_DIR := server
 INSTALLER_WEBUI_DIR := ui
@@ -32,7 +30,6 @@ ifndef CONTAINER_REGISTRY
 CONTAINER_REGISTRY := ${CONTAINER_REGISTRY_DEFAULT_SERVER}/${CONTAINER_REGISTRY_NAMESPACE}
 endif
 
-.ONESHELL:
 assemble: clean resolve-registry build-server build-web-ui
 	@echo "Building docker image: ${CONTAINER_REGISTRY}/${IMAGE_NAME}:${IMAGE_TAG}"
 	docker rmi ${CONTAINER_REGISTRY}/${IMAGE_NAME}:${IMAGE_TAG}
@@ -52,23 +49,17 @@ login-to-registry:
 logout-from-registry:
 	docker logout ${CONTAINER_REGISTRY}
 
-.ONESHELL:
 push-image: assemble
 	@echo "Pushing image to registry: ${CONTAINER_REGISTRY}/${IMAGE_NAME}:${IMAGE_TAG}"
 	docker push --all-tags ${CONTAINER_REGISTRY}/${IMAGE_NAME}
 
-.ONESHELL:
 build-server:
 	@echo "Building installer server"
-	cd ${INSTALLER_SERVER_DIR}
-	make build
-	cd ..
+	make build -C ${INSTALLER_SERVER_DIR}
 	cp ${INSTALLER_SERVER_DIR}/build/server ${BUILD_DIR}
 
-.ONESHELL:
 build-web-ui:
 	@echo "Building installer web UI"
 	cd ${INSTALLER_WEBUI_DIR}
-	make build
-	cd ..
+	make build -C ${INSTALLER_WEBUI_DIR}
 	cp -ap ${INSTALLER_WEBUI_DIR}/build/. ${BUILD_DIR}/public

--- a/server/Makefile
+++ b/server/Makefile
@@ -1,4 +1,3 @@
-export SHELL := /usr/bin/bash
 # checking for go on this line
 ifeq (, $(shell which go))
 $(error "No go in $(PATH), can't go anywhere...")

--- a/ui/Makefile
+++ b/ui/Makefile
@@ -1,20 +1,15 @@
-export SHELL := /usr/bin/bash
-NVM_SCRIPT := ${HOME}/.nvm/nvm.sh
+NVM_SCRIPT ?= ${HOME}/.nvm/nvm.sh
 
 all: test build
 
 # this will print a message if nvm is not installed
 ${NVM_SCRIPT}:
-	@echo NVM was not found!
+	@echo NVM was not found! You can provide NVM_SCRIPT to make with the path..
 	false
 
 .PHONY: nvm
-.ONESHELL:
 nvm: ${NVM_SCRIPT} # will run provided command in environment with nvm
-	. ${NVM_SCRIPT} --no-use
-	nvm install
-	npm i
-	${CMD}
+	. ${NVM_SCRIPT} --no-use && nvm install && npm i && ${CMD}
 
 .PHONY: build
 build: ${NVM_SCRIPT}


### PR DESCRIPTION
A start on this.

Things I found:
We don't really need the SHELL setting.  It uses /bin/sh by default.

Macs (at least mine and looked like Kevin's) don't support .ONESHELL so removed that and batched up stuff where necessary.

If the makefile still can't find nvm.sh, you can do "make NVM_SCRIPT=/path/to/nvm.sh" to set it.

My Mac is old and npm fails to run on it due to some strange c compiler issues so can't go much further with it.

Anyway, please give this a try and feel free to add/remove/update/whatever the PR to make it work better!

