### PR TITLE
Add cancel API

### DIFF
--- a/server/azure/client.go
+++ b/server/azure/client.go
@@ -137,6 +137,14 @@ func GetDeployment(ctx context.Context, client *armresources.DeploymentsClient, 
 	return model.NewDeploymentResult(details.DeploymentExtended), err
 }
 
+func CancelDeployment(ctx context.Context, client *armresources.DeploymentsClient, name string) error {
+	_, err := client.Cancel(ctx, config.GetEnvironment().RESOURCE_GROUP_NAME, name, &armresources.DeploymentsClientCancelOptions{})
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
 // Delete Azure storage account
 func DeleteStorageAccount(resourceGroupName string, storageAccountName string) error {
 	storageClient, err := armstorage.NewAccountsClient(getAzureInfo().Subscription, getAzureInfo().Credentials, nil)

--- a/server/engine/engine.go
+++ b/server/engine/engine.go
@@ -52,7 +52,7 @@ func (engine *Engine) Run() {
 				engine.database.Instance.Save(&latestExecution)
 
 				engine.startExecution(step, &model.Execution{}, &executionWaitGroup)
-			case model.Succeeded:
+			case model.Succeeded, model.Canceled:
 				continue
 			}
 			currentExecutions[stepIndex] = &latestExecution
@@ -66,24 +66,30 @@ func (engine *Engine) Run() {
 		if engine.context.Err() == nil {
 			log.Info("Checking execution status of completed steps...")
 			// first check all executions for those that can't be restarted anymore
-			foundPermanentlyFailedExecution := false
+			terminateMainLoop := false
 			for _, execution := range currentExecutions {
-				if execution != nil && execution.Status != model.Succeeded && execution.ExecutionCount == engine.maxExecutionRestarts {
+				if execution != nil && execution.Status == model.Canceled {
+					// cancelled execution means the whole process will be cancelled
+					log.Warn("Found cancelled execution.")
+					terminateMainLoop = true
+					break
+				}
+				if execution != nil && execution.Status != model.Succeeded && execution.Status != model.Canceled && execution.ExecutionCount == engine.maxExecutionRestarts {
 					log.Error("Found failed deployment step that can not be restarted again.")
-					foundPermanentlyFailedExecution = true
+					terminateMainLoop = true
 					execution.Status = model.PermanentlyFailed
 					engine.database.Instance.Save(execution)
 					break
 				}
 			}
-			if foundPermanentlyFailedExecution {
-				log.Info("Will terminate main loop because at least one deployment step can not be restarted.")
+			if terminateMainLoop {
+				log.Info("Will terminate main loop because steps can't be restarted or deployment is being cancelled.")
 				break
 			}
 			// check all executions for those can be restarted
 			for _, execution := range currentExecutions {
 				// check if step can be restarted
-				if execution != nil && execution.Status != model.Succeeded {
+				if execution != nil && execution.Status != model.Succeeded && execution.Status != model.Canceled {
 					restartRequired = true
 					engine.startWaitingForRestart(execution, &executionWaitGroup)
 				}
@@ -291,4 +297,11 @@ func (engine *Engine) runStep(step model.Step, execution *model.Execution, waitG
 	// store execution
 	model.UpdateExecution(execution, deployResponse, "")
 	engine.database.Instance.Save(&execution)
+}
+
+func (engine *Engine) CancelStep(step model.Step) {
+	err := azure.CancelDeployment(engine.context, engine.deploymentsClient, step.Name)
+	if err != nil {
+		log.Errorf("Couldn't cancel deployment: %v", err)
+	}
 }

--- a/server/engine/engine.go
+++ b/server/engine/engine.go
@@ -37,7 +37,7 @@ func (engine *Engine) Run() {
 		currentExecutions := make([]*model.Execution, len(stepsToRun))
 
 		for stepIndex, step := range stepsToRun {
-			latestExecution := engine.getLatestExecution(step)
+			latestExecution := engine.GetLatestExecution(step)
 
 			switch latestExecution.Status {
 			case model.Started:
@@ -151,7 +151,7 @@ func (engine *Engine) Done() <-chan struct{} {
 	return engine.done
 }
 
-func (engine *Engine) getLatestExecution(step model.Step) model.Execution {
+func (engine *Engine) GetLatestExecution(step model.Step) model.Execution {
 	latestExecution := model.Execution{}
 	// Avoid GORM error from Last() if no executions yet
 	var count int64

--- a/server/handler/common.go
+++ b/server/handler/common.go
@@ -3,12 +3,14 @@ package handler
 import (
 	"encoding/json"
 	"net/http"
+	"server/engine"
 
 	log "github.com/sirupsen/logrus"
 	"gorm.io/gorm"
 )
 
 type HandleFuncWithDB func(db *gorm.DB, w http.ResponseWriter, r *http.Request)
+type HandleFuncWithDBAndEngine func(db *gorm.DB, engine *engine.Engine, w http.ResponseWriter, r *http.Request)
 
 func respondJSON(w http.ResponseWriter, status int, payload interface{}) {
 	response, err := json.Marshal(payload)

--- a/server/handler/handler_test.go
+++ b/server/handler/handler_test.go
@@ -130,7 +130,7 @@ func testHttpRoute(t *testing.T, method string, path string, body io.Reader) *ht
 	handler.ConfigureAuthenticationForTesting(true)
 	rec := httptest.NewRecorder()
 
-	installer := api.NewApp(database)
+	installer := api.NewApp(database, nil)
 	installer.GetRouter().ServeHTTP(rec, req)
 
 	return rec

--- a/server/handler/status.go
+++ b/server/handler/status.go
@@ -13,6 +13,7 @@ type InstallationStatus string
 
 const (
 	Deploying InstallationStatus = "DEPLOYING"
+	Canceled  InstallationStatus = "CANCELED"
 	Failed    InstallationStatus = "FAILED"
 	Done      InstallationStatus = "DONE"
 )
@@ -29,6 +30,10 @@ func Status(db *gorm.DB, w http.ResponseWriter, r *http.Request) {
 		latestExecution := getLatestExecution(db, step)
 		if latestExecution.Status == model.PermanentlyFailed {
 			status = Failed
+			break
+		} else if latestExecution.Status == model.Canceled {
+			status = Canceled
+			break
 		} else if latestExecution.Status != model.Succeeded {
 			status = Deploying
 		}

--- a/server/handler/steps.go
+++ b/server/handler/steps.go
@@ -3,6 +3,7 @@ package handler
 import (
 	"net/http"
 
+	"server/engine"
 	"server/model"
 
 	"github.com/gorilla/mux"
@@ -10,8 +11,7 @@ import (
 )
 
 func GetAllSteps(db *gorm.DB, w http.ResponseWriter, r *http.Request) {
-	steps := []model.Step{}
-	db.Model(&model.Step{}).Preload("Executions").Find(&steps)
+	steps := getAllSteps(db)
 	respondJSON(w, http.StatusOK, steps)
 }
 
@@ -23,6 +23,34 @@ func GetStep(db *gorm.DB, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	respondJSON(w, http.StatusOK, step)
+}
+
+func CancelAllSteps(db *gorm.DB, engine *engine.Engine, w http.ResponseWriter, r *http.Request) {
+	steps := getAllSteps(db)
+	// first mark all non executing steps as cancelled
+	for _, aStep := range steps {
+		if len(aStep.Executions) == 0 {
+			db.Save(&model.Execution{
+				Status: model.Canceled,
+				StepID: aStep.ID,
+			})
+		}
+	}
+	// refresh steps
+	steps = getAllSteps(db)
+	// find currently running steps and cancel them
+	for _, aStep := range steps {
+		// check status of last one, there should not be any steps with no executions
+		if aStep.Executions[len(aStep.Executions)-1].Status == model.Started {
+			engine.CancelStep(aStep)
+		}
+	}
+}
+
+func getAllSteps(db *gorm.DB) []model.Step {
+	steps := []model.Step{}
+	db.Model(&model.Step{}).Preload("Executions").Find(&steps)
+	return steps
 }
 
 func getStepOr404(db *gorm.DB, id string, w http.ResponseWriter, r *http.Request) *model.Step {

--- a/server/handler/steps.go
+++ b/server/handler/steps.go
@@ -41,7 +41,7 @@ func CancelAllSteps(db *gorm.DB, engine *engine.Engine, w http.ResponseWriter, r
 	// find currently running steps and cancel them
 	for _, aStep := range steps {
 		// check status of last one, there should not be any steps with no executions
-		if aStep.Executions[len(aStep.Executions)-1].Status == model.Started {
+		if engine.GetLatestExecution(aStep).Status == model.Started {
 			engine.CancelStep(aStep)
 		}
 	}

--- a/server/main.go
+++ b/server/main.go
@@ -25,7 +25,7 @@ func main() {
 
 	engine := engine.NewEngine(exit.Context(), db, deploymentsClient)
 
-	app := api.NewApp(db)
+	app := api.NewApp(db, engine)
 
 	// Start listening for shutdown signal
 	exit.Start()

--- a/server/model/azureModel.go
+++ b/server/model/azureModel.go
@@ -108,10 +108,12 @@ type DeploymentResult struct {
 
 func NewDeploymentResult(response armresources.DeploymentExtended) *DeploymentResult {
 	var status ExecutionStatus
-	if *response.Properties.ProvisioningState == armresources.ProvisioningStateSucceeded {
+	switch *response.Properties.ProvisioningState {
+	case armresources.ProvisioningStateSucceeded:
 		status = Succeeded
-	} else {
-		// Assume anything but Succeeded is failed
+	case armresources.ProvisioningStateCanceled:
+		status = Canceled
+	default:
 		status = Failed
 	}
 	// make sure response outputs are always there, even if empty

--- a/server/model/enum.go
+++ b/server/model/enum.go
@@ -12,6 +12,7 @@ const (
 	Restart           ExecutionStatus = "Restart"
 	Restarted         ExecutionStatus = "Restarted"
 	RestartTimedOut   ExecutionStatus = "RestartTimedOut"
+	Canceled          ExecutionStatus = "Canceled"
 )
 
 // Allow GORM to store the string value of ExecutionStatus

--- a/ui/src/app/Deployment/Deployment.tsx
+++ b/ui/src/app/Deployment/Deployment.tsx
@@ -8,7 +8,6 @@ export const Deployment = () => {
 
   const [stepsData, setStepsData] = useState<DeploymentStepData[]>()
   const [progressData, setProgressData] = useState<DeploymentProgressData>()
-  const [isCancelled, setCancelled] = useState(false)
 
   const fetchData = async () => {
     try {
@@ -33,8 +32,8 @@ export const Deployment = () => {
   return (
     <>
       {/* TODO Add some place holder for case when data is not available */}
-      {stepsData &&<DeploymentSteps stepsData={stepsData} isCancelled={isCancelled}></DeploymentSteps>}
-      {progressData  && <DeploymentProgress progressData={progressData} setCancelled={setCancelled}></DeploymentProgress>}
+      {stepsData &&<DeploymentSteps stepsData={stepsData}></DeploymentSteps>}
+      {progressData  && <DeploymentProgress progressData={progressData}></DeploymentProgress>}
     </>
   )
 }

--- a/ui/src/app/Deployment/DeploymentProgress/CancelDeployment.tsx
+++ b/ui/src/app/Deployment/DeploymentProgress/CancelDeployment.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Bullseye, Button, Modal, ModalVariant, StackItem } from '@patternfly/react-core';
 import { cancelDeployment } from '../../apis/deployment';
 
-export const CancelDeployment = ({setCancelled}) => {
+export const CancelDeployment = () => {
 
   const [isModalOpen, setIsModalOpen] = React.useState(false);
 
@@ -15,16 +15,9 @@ export const CancelDeployment = ({setCancelled}) => {
       const cancelled = await cancelDeployment()
       // TODO add visual confirmation that deployment was cancelled
       if(cancelled){
-        setCancelled(true);
-        document.getElementsByClassName("cancelButton")[0].remove();
-        document.getElementsByClassName("retryButton")[0]?.remove();
-        if(document.getElementsByClassName("infoText")){document.getElementsByClassName("infoText")[0].innerHTML = 
-          "Your Ansible on Azure deployment is cancelled. You still need to delete the managed application from your Azure subscription."+
-          "In the Azure Portal, navigate to 'Resource Groups', and then to the resource group where you deployed the instance of the managed application. "+
-          "Select the managed application from the list of resources and then click 'Delete' to remove all resources associated with the managed application"}
         setIsModalOpen(!isModalOpen);
       }
-      
+      // TODO add something in case cancel was not successful
     } catch (error) {
       console.log(error)
     }

--- a/ui/src/app/Deployment/DeploymentProgress/DeploymentProgress.css
+++ b/ui/src/app/Deployment/DeploymentProgress/DeploymentProgress.css
@@ -6,3 +6,7 @@
     background-color: white;
     width: 75%;
 }
+
+.deployProgress h1 {
+    text-align: center;
+}

--- a/ui/src/app/Deployment/DeploymentProgress/DeploymentProgress.tsx
+++ b/ui/src/app/Deployment/DeploymentProgress/DeploymentProgress.tsx
@@ -1,45 +1,59 @@
-import React, { Dispatch, SetStateAction } from 'react';
+import React from 'react';
 import { RestartStep } from './RestartStep';
 import { ProgressBar } from './ProgressBar';
 import { CancelDeployment } from './CancelDeployment';
 import { DeploymentProgressData} from '../../apis/types';
 import './DeploymentProgress.css'
-import { PageSection, Bullseye, Stack } from '@patternfly/react-core';
+import { PageSection, Bullseye, Stack, StackItem, Text, TextVariants } from '@patternfly/react-core';
 
 interface IDeploymentProgressProps {
   progressData: DeploymentProgressData
-  setCancelled: Dispatch<SetStateAction<boolean>>
 }
 
 
-export const DeploymentProgress = ({ progressData, setCancelled}: IDeploymentProgressProps ) => {
+export const DeploymentProgress = ({ progressData }: IDeploymentProgressProps ) => {
+
+  // set a deployment message based on the status
+  let  deploymentMessage = ""
+  if (progressData.isComplete) {
+    deploymentMessage = "Your Ansible Automation Platform deployment is now complete."
+  } else if (progressData.isCanceled) {
+    deploymentMessage =
+      "Your Ansible on Azure deployment is cancelled. You still need to delete the managed application from your Azure subscription." +
+      "In the Azure Portal, navigate to 'Resource Groups', and then to the resource group where you deployed the instance of the managed application. " +
+      "Select the managed application from the list of resources and then click 'Delete' to remove all resources associated with the managed application"
+  } else if (progressData.failedStepIds.length > 0) {
+    deploymentMessage = `Deployment step "${progressData.failedStepNames[0]}" failed. Press the Restart button below to restart it.`
+  } else {
+    deploymentMessage = ""
+  }
 
   // render restart for the first failed step
-  const restartStep = (progressData.failedStepIds.length > 0 ?
-    <RestartStep stepExId={progressData.failedExId} stepName={progressData.failedStepNames[0]} /> :
+  const restartStep = (progressData.failedStepIds.length > 0 && !progressData.isCanceled ?
+    <RestartStep stepExId={progressData.failedExId} /> :
     <></>
   )
 
   // render progress bar only if no failed steps
   const progressBar = (progressData.failedStepIds.length === 0 ?
-    <ProgressBar progressPercent={progressData.progress} isComplete={progressData.isComplete}></ProgressBar> :
+    <ProgressBar progressPercent={progressData.progress} ></ProgressBar> :
     <></>
   )
 
-  const cancelButton = (!progressData.isComplete ? <CancelDeployment setCancelled={setCancelled}/> : <></>)
+  const cancelButton = ( !progressData.isComplete && !progressData.isCanceled ? <CancelDeployment/> : <></>)
 
   return (
-
-    <div >
+    <>
       <PageSection>
         <Bullseye>
           <Stack hasGutter className='deployProgress'>
-            {restartStep}
-            {progressBar}
-            {cancelButton}
+            { deploymentMessage.length > 0 && <StackItem><Text component={TextVariants.h1}>{ deploymentMessage }</Text></StackItem>}
+            { restartStep }
+            { progressBar }
+            { cancelButton }
           </Stack>
         </Bullseye>
       </PageSection>
-    </div>
+    </>
   )
 }

--- a/ui/src/app/Deployment/DeploymentProgress/ProgressBar.tsx
+++ b/ui/src/app/Deployment/DeploymentProgress/ProgressBar.tsx
@@ -1,23 +1,16 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import React from 'react';
-import { Progress, StackItem, Text } from '@patternfly/react-core';
+import { Progress, StackItem } from '@patternfly/react-core';
 import './ProgressBar.css'
 
 interface IProgressBarProps {
   progressPercent: number
-  isComplete: boolean
 }
 
-export const ProgressBar = ({ progressPercent, isComplete }: IProgressBarProps) => {
-
+export const ProgressBar = ({ progressPercent }: IProgressBarProps) => {
   return (
     <StackItem className='progress'>
       <Progress className='infoText' value={progressPercent} title="Overall progress" />
-      <br></br>
-      <div>
-        {isComplete ? <Text className="SuccessMessage" >Your Ansible Automation Platform deployment is now complete.</Text> :
-          <></>}
-      </div>
     </StackItem>
   )
 };

--- a/ui/src/app/Deployment/DeploymentProgress/RestartStep.tsx
+++ b/ui/src/app/Deployment/DeploymentProgress/RestartStep.tsx
@@ -4,8 +4,6 @@ import { restartStep } from '../../apis/deployment';
 
 interface IRestartDeploymentProps {
   stepExId: number
-  stepName: string
-
 }
 interface LoadingPropsType {
   spinnerAriaValueText: string;
@@ -14,7 +12,7 @@ interface LoadingPropsType {
   isLoading: boolean;
 }
 
-export const RestartStep = ({ stepExId, stepName }: IRestartDeploymentProps) => {
+export const RestartStep = ({ stepExId }: IRestartDeploymentProps) => {
 
   const [isPrimaryLoading, setIsPrimaryLoading] = React.useState<boolean>(false);
   const primaryLoadingProps = {} as LoadingPropsType;
@@ -26,8 +24,7 @@ export const RestartStep = ({ stepExId, stepName }: IRestartDeploymentProps) => 
     event.preventDefault();
     try {
       setIsPrimaryLoading(!isPrimaryLoading)
-      const restarted = await restartStep(stepExId);
-      console.log(`Step ${stepExId} restarted: ${restarted}`)  
+      await restartStep(stepExId);
     } catch (error) {
       console.log(error)
     }
@@ -37,16 +34,11 @@ export const RestartStep = ({ stepExId, stepName }: IRestartDeploymentProps) => 
   }
 
   return (
-    <><StackItem>
+    <StackItem>
       <Bullseye>
-        <h2 className='infoText'> Deployment step "{stepName}" failed. Press the Restart button below to restart it.</h2>
+        <Button className='retryButton' id="primary-loading-button" variant="primary" onClick={handleRestart} {...primaryLoadingProps}>
+          {isPrimaryLoading ? 'Restarting Step' : 'Restart Step'}</Button>
       </Bullseye>
     </StackItem>
-      <StackItem>
-        <Bullseye>
-          <Button className='retryButton' id="primary-loading-button" variant="primary" onClick={handleRestart} {...primaryLoadingProps}>
-            {isPrimaryLoading ? 'Restarting Step' : 'Restart Step'}</Button>
-        </Bullseye>
-      </StackItem></>
   );
 };

--- a/ui/src/app/Deployment/DeploymentSteps/Step.tsx
+++ b/ui/src/app/Deployment/DeploymentSteps/Step.tsx
@@ -5,16 +5,15 @@ import { DeploymentStepData } from '../../apis/types';
 
 interface IStepProps {
   stepData: DeploymentStepData
-  isCancelled:boolean
 }
 
 
-export const DeploymentStep = ({ stepData, isCancelled }: IStepProps) => {
+export const DeploymentStep = ({ stepData }: IStepProps) => {
 
   return (
     <ListItem className='service-list pf-u-box-shadow-md'>
       <Flex className='step-name'>{stepData.name}
-        {stepData.status && <StepStatus stepStatusData={stepData.status} isCancelled={isCancelled}/>}
+        {stepData.status && <StepStatus stepStatusData={stepData.status} />}
       </Flex>
     </ListItem>
   )

--- a/ui/src/app/Deployment/DeploymentSteps/StepStatus.tsx
+++ b/ui/src/app/Deployment/DeploymentSteps/StepStatus.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import { FlexItem, Icon, TextVariants, Text, Tooltip, Flex } from '@patternfly/react-core';
 import CheckCircleIcon from '@patternfly/react-icons/dist/esm/icons/check-circle-icon';
 import ExclamationCircleIcon from '@patternfly/react-icons/dist/esm/icons/exclamation-circle-icon';
@@ -6,43 +6,29 @@ import { DeploymentStepStatusData, StepStatuses } from '../../apis/types';
 
 interface IStepStatusProps {
   stepStatusData: DeploymentStepStatusData
-  isCancelled:boolean
 }
 
-export const StepStatus = ({ stepStatusData, isCancelled}: IStepStatusProps) => {
+export const StepStatus = ({ stepStatusData }: IStepStatusProps) => {
 
-
-  const startState = (stepStatusData.status === StepStatuses.STARTED ?
-    <Icon className='icon1' isInProgress={true}><CheckCircleIcon /></Icon> :
-    <></>
-  );
-
-  const stepDuration = ((stepStatusData.status === StepStatuses.SUCCEEDED || stepStatusData.status === StepStatuses.FAILED) ?
-    <Text className='timeTaken' component={TextVariants.h5}>({stepStatusData.duration})</Text> :
-    <></>
-  );
-
-
-  const attemptsText = (stepStatusData.status === StepStatuses.FAILED ?
-    <Text className='attempt' component={TextVariants.h5}>({stepStatusData.attempts} attempts)</Text> :
-    <></>
-  );
-
-  const statusTooltip = (stepStatusData.status === StepStatuses.SUCCEEDED ?
-    <Tooltip content={<div>Success</div>}><Icon className='icon1' status="success"><CheckCircleIcon /></Icon></Tooltip> :
-    stepStatusData.status === StepStatuses.FAILED ?
-      <Tooltip content={<div>{stepStatusData.error}</div>}><Icon className='icon1' status="danger"><ExclamationCircleIcon /></Icon></Tooltip> :
-      <></>
-  )
-
-  const cancelledState = (isCancelled===true ? <Tooltip content={<div>{"Cancelled"}</div>}><Icon className='icon1' status="warning"><ExclamationCircleIcon /></Icon></Tooltip> :<></>)
+  const hasStarted = (stepStatusData.status === StepStatuses.STARTED)
+  const hasSucceeded = (stepStatusData.status === StepStatuses.SUCCEEDED)
+  const hasFailed = (stepStatusData.status === StepStatuses.FAILED)
+  const hasBeenCanceled = (stepStatusData.status === StepStatuses.CANCELED)
 
   return (
     <Flex align={{ default: 'alignRight' }} className='deployment-info'>
-      <FlexItem>{stepDuration}</FlexItem>
-      <FlexItem>{attemptsText}</FlexItem>
-      {isCancelled ? <FlexItem className="statusTooltip" align={{ default: 'alignRight' }} >{cancelledState}</FlexItem>:
-      <FlexItem className="statusTooltip" align={{ default: 'alignRight' }} >{statusTooltip}{startState}</FlexItem>}
+      <FlexItem>
+        { (hasSucceeded || hasFailed) && <Text className='timeTaken' component={TextVariants.h5}>({stepStatusData.duration})</Text> }
+      </FlexItem>
+      <FlexItem>
+        { hasFailed && <Text className='attempt' component={TextVariants.h5}>({stepStatusData.attempts} attempts)</Text> }
+      </FlexItem>
+      <FlexItem className="statusTooltip" align={{ default: 'alignRight' }}>
+        { hasBeenCanceled && <Tooltip removeFindDomNode={true} content={<div>{"Cancelled"}</div>}><Icon className='icon1' status="warning"><ExclamationCircleIcon /></Icon></Tooltip> }
+        { hasSucceeded && <Tooltip removeFindDomNode={true} content={<div>Success</div>}><Icon className='icon1' status="success"><CheckCircleIcon /></Icon></Tooltip> }
+        { hasFailed && <Tooltip removeFindDomNode={true} content={stepStatusData.error}><Icon className='icon1' status="danger"><ExclamationCircleIcon /></Icon></Tooltip> }
+        { hasStarted && <Icon className='icon1' isInProgress={true}><CheckCircleIcon /></Icon> }
+      </FlexItem>
     </Flex>
   )
 };

--- a/ui/src/app/Deployment/DeploymentSteps/Steps.tsx
+++ b/ui/src/app/Deployment/DeploymentSteps/Steps.tsx
@@ -7,11 +7,10 @@ import './Steps.css'
 
 interface IDeploymentStepsProps {
   stepsData: DeploymentStepData[]
-  isCancelled:boolean
 }
 
 
-export const DeploymentSteps = ({ stepsData, isCancelled }: IDeploymentStepsProps, ) => {
+export const DeploymentSteps = ({ stepsData }: IDeploymentStepsProps, ) => {
   return (
     <>
       <PageSection variant={PageSectionVariants.light}>
@@ -28,7 +27,7 @@ export const DeploymentSteps = ({ stepsData, isCancelled }: IDeploymentStepsProp
               </Title>
               <div className='deploy-step pf-u-box-shadow-md'>
                 <List isPlain isBordered >
-                  {stepsData?.map(stepData => (<DeploymentStep key={stepData.id} stepData={stepData} isCancelled={isCancelled}></DeploymentStep>))}
+                  {stepsData?.map(stepData => (<DeploymentStep key={stepData.id} stepData={stepData}></DeploymentStep>))}
                 </List>
               </div>
             </StackItem>

--- a/ui/src/app/apis/deployment.tsx
+++ b/ui/src/app/apis/deployment.tsx
@@ -26,7 +26,7 @@ export function restartStep(id: number): Promise<boolean> {
 }
 
 export function cancelDeployment(): Promise<boolean> {
-	return fetch(`${baseURI}/terminate?confirmation=yes`,
+	return fetch(`${baseURI}/cancelAllSteps`,
 		{
 			method: 'POST',
 			headers: { 'Content-Type': 'application/json' }

--- a/ui/src/app/apis/types.tsx
+++ b/ui/src/app/apis/types.tsx
@@ -2,7 +2,8 @@ export enum StepStatuses {
 	PENDING,
 	STARTED,
 	SUCCEEDED,
-	FAILED
+	FAILED,
+	CANCELED
 }
 
 export class DeploymentStepStatusData {
@@ -25,15 +26,6 @@ export class DeploymentStepStatusData {
 			const stepExecution = executions[executions.length -1]
 			this.lastExecutionId = stepExecution.ID
 			// map fields from the API payload into this class fields
-			/* server uses following statuses:
-				"Started"
-				"Failed"
-				"PermanentlyFailed"
-				"Succeeded"
-				"Restart"
-				"Restarted"
-				"RestartTimedOut"
-			*/
 			switch (stepExecution.status) {
 				case "Started":
 				case "Restarted":
@@ -47,6 +39,9 @@ export class DeploymentStepStatusData {
 					break
 				case "Succeeded":
 					this.status = StepStatuses.SUCCEEDED
+					break
+				case "Canceled":
+					this.status = StepStatuses.CANCELED
 					break
 				default:
 					this.status = StepStatuses.PENDING
@@ -82,6 +77,7 @@ export class DeploymentProgressData {
 	failedStepNames: string[] = []
 	failedExId:number =-1
 	isComplete:boolean = false
+	isCanceled:boolean = false
 	constructor(steps?:DeploymentStepData[]) {
 		if (Array.isArray(steps) && steps.length > 0) {
 			const succeeded = steps.reduce(
@@ -95,6 +91,7 @@ export class DeploymentProgressData {
 			this.failedStepIds = failedSteps.map((failedStep)=>failedStep.id)
 			this.failedStepNames = failedSteps.map((failedStep)=>failedStep.name)
 			this.isComplete = this.progress === 100
+			this.isCanceled = steps.some((currentStep) => currentStep.status?.status === StepStatuses.CANCELED)
 			// TODO Fix this up and probably move somewhere else (not exactly progress related)
 			if(failedSteps[0] != null && failedSteps[0].status != null)
 			{


### PR DESCRIPTION
This PR adds a cancel API and updates UI to make use of it.

Calling the cancel API will do two things:
- mark all un-executed(pending) deployment steps as cancelled (add execution with status Cancelled). This step is done first to prevent deployment from progressing further.
- call cancel on all currently running deployments
In addition to cancelling the deployment steps, there is a new step status "canceled"

The UI has been enhanced to make use of the cancel API instead of terminating the whole deployment. With the new API and new status, the UI components can use the step status to decide whether the deployment has been cancelled. 