### PR TITLE
test target in makefile - disable file watch

### DIFF
--- a/ui/Makefile
+++ b/ui/Makefile
@@ -17,7 +17,7 @@ build: ${NVM_SCRIPT}
 
 .PHONY: test
 test: ${NVM_SCRIPT}
-	make nvm CMD="npm run test"
+	make nvm CMD="npm run test -- --watchAll=false"
 
 .PHONY: audit-prod-only
 audit-prod-only: ${NVM_SCRIPT}


### PR DESCRIPTION
This removes file watching for the make file target `test` in the UI project to allow for non-interactive test executions.

> NOTE: test watching during development still occurs since the package.json test script was not modified.

Resolves ansible/azure-aap-deployment-driver#19