### PR TITLE
Use acme.sh from releases and add store acme and driver tags

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,15 +4,20 @@ USER root
 
 WORKDIR /opt/app-root/src/
 
-# Install socat tools required by acme.sh and download acme.sh (but don't install)
+ARG ACME_RELEASE_TAG=3.0.5
+ARG DRIVER_RELEASE_TAG=dev
+
+# Install socat tools required by acme.sh and download acme.sh from version/tag (but don't install)
 RUN yum -y --repo ubi-9-appstream-rpms install socat && \
-  curl -o acme.installer.sh https://get.acme.sh && chmod +x acme.installer.sh
+  curl -L -o acme.zip https://github.com/acmesh-official/acme.sh/archive/refs/tags/v${ACME_RELEASE_TAG}.zip && \
+  unzip -qoj acme.zip acme.sh-${ACME_RELEASE_TAG}/acme.sh -d . && rm acme.zip && \
+  echo "ACME=${ACME_RELEASE_TAG}" >> versions && echo "DRIVER=${DRIVER_RELEASE_TAG}" >> versions && ls -al && cat versions
 
 ADD ["nginx", "/etc/nginx/"]
 ADD ["start.sh", "build/server", "./"]
 ADD ["build/public", "/var/www/aapinstaller/public"]
 
-RUN chmod +x ./server && chmod +x ./start.sh
+RUN chmod +x ./acme.sh ./server && chmod +x ./start.sh
 
 VOLUME [ "/installerstore" ]
 

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ BUILD_DIR := build
 INSTALLER_SERVER_DIR := server
 INSTALLER_WEBUI_DIR := ui
 CONTAINER_REGISTRY_DEFAULT_NAMESPACE ?= aoc-${USER}
+DRIVER_RELEASE_TAG ?=$(shell git rev-parse --short HEAD)
 IMAGE_NAME ?= installer
 IMAGE_TAG ?= latest
 
@@ -34,7 +35,7 @@ endif
 
 assemble: clean resolve-registry build-server build-web-ui
 	@echo "Building docker image: ${CONTAINER_REGISTRY}/${IMAGE_NAME}:${IMAGE_TAG}"
-	docker build --build-arg DRIVER_RELEASE_TAG=${IMAGE_TAG} -t ${CONTAINER_REGISTRY}/${IMAGE_NAME}:${IMAGE_TAG} .
+	docker build --build-arg DRIVER_RELEASE_TAG=${DRIVER_RELEASE_TAG} -t ${CONTAINER_REGISTRY}/${IMAGE_NAME}:${IMAGE_TAG} .
 	docker tag ${CONTAINER_REGISTRY}/${IMAGE_NAME}:${IMAGE_TAG} ${CONTAINER_REGISTRY}/${IMAGE_NAME}:latest
 
 save-image: assemble

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ endif
 
 assemble: clean resolve-registry build-server build-web-ui
 	@echo "Building docker image: ${CONTAINER_REGISTRY}/${IMAGE_NAME}:${IMAGE_TAG}"
-	docker build -t ${CONTAINER_REGISTRY}/${IMAGE_NAME}:${IMAGE_TAG} .
+	docker build --build-arg DRIVER_RELEASE_TAG=${IMAGE_TAG} -t ${CONTAINER_REGISTRY}/${IMAGE_NAME}:${IMAGE_TAG} .
 	docker tag ${CONTAINER_REGISTRY}/${IMAGE_NAME}:${IMAGE_TAG} ${CONTAINER_REGISTRY}/${IMAGE_NAME}:latest
 
 save-image: assemble

--- a/start.sh
+++ b/start.sh
@@ -92,7 +92,7 @@ fi
 if [ ! -f ~/.acme.sh/.acme.sh.installed. ]; then
   # Run the acme.sh installation step
   log "Installing acme.sh..."
-  ./acme.installer.sh email=${ACME_ACCOUNT_EMAIL} --install --force --no-color
+  ./acme.sh --install --email aoc-automation@redhat.com --force --no-color
   RC=$?
   if [ ${RC} -ne 0 ]; then
     log "Failed to install acme.sh script. See previous output for more information."


### PR DESCRIPTION
The current Docker file is using <https://get.acme.sh> which is from another repo and it always pulls from the main, rather than released version. With the change in this PR, our docker file pins the acme.sh to a tag/release leading to reproducible builds.
Additionally this PR stores the tag of the ACME.sh release and the tag of the deployment driver in a file named `versions`. This will be later used by the engine to log the versions of the dependencies for debugging purposes.