### PR TITLE
Create a new table called telemetries to store Installer telemetry data

### DIFF
--- a/server/persistence/db.go
+++ b/server/persistence/db.go
@@ -1,7 +1,6 @@
 package persistence
 
 import (
-	"fmt"
 	"server/model"
 	"server/telemetry"
 
@@ -34,12 +33,6 @@ func newDB(dbPath string, migrationModels ...interface{}) (*Database, error) {
 	if err != nil {
 		return nil, err
 	}
-
-	result, _ := db.Debug().Migrator().ColumnTypes(&telemetry.Telemetry{})
-	for _, v := range result {
-		fmt.Println(v.Name())
-	}
-
 	return &Database{
 		Instance: db,
 	}, nil

--- a/server/persistence/db.go
+++ b/server/persistence/db.go
@@ -1,7 +1,9 @@
 package persistence
 
 import (
+	"fmt"
 	"server/model"
+	"server/telemetry"
 
 	log "github.com/sirupsen/logrus"
 	"gorm.io/gorm"
@@ -28,10 +30,16 @@ func NewInMemoryDB() *Database {
 }
 
 func newDB(dbPath string, migrationModels ...interface{}) (*Database, error) {
-	db, err := newSqliteDB(dbPath, &model.Step{}, &model.Execution{}, &model.Output{}, &model.Status{}, &model.SessionConfig{})
+	db, err := newSqliteDB(dbPath, &model.Step{}, &model.Execution{}, &model.Output{}, &model.Status{}, &model.SessionConfig{}, &telemetry.Telemetry{})
 	if err != nil {
 		return nil, err
 	}
+
+	result, _ := db.Debug().Migrator().ColumnTypes(&telemetry.Telemetry{})
+	for _, v := range result {
+		fmt.Println(v.Name())
+	}
+
 	return &Database{
 		Instance: db,
 	}, nil

--- a/server/persistence/persistence_test.go
+++ b/server/persistence/persistence_test.go
@@ -2,7 +2,9 @@ package persistence_test
 
 import (
 	"os"
+	"server/model"
 	"server/persistence"
+	"server/telemetry"
 	"server/test"
 	"testing"
 
@@ -38,6 +40,24 @@ func TestRealDatabase(t *testing.T) {
 func TestInMemoryDatabase(t *testing.T) {
 	db := persistence.NewInMemoryDB()
 	testDb(t, db)
+}
+func TestTelemetryTable(t *testing.T) {
+
+	const DB_FILENAME = "tmp.db"
+	db := persistence.NewPersistentDB(DB_FILENAME)
+	testData := &telemetry.Telemetry{
+		BaseModel:   model.BaseModel{},
+		MetricName:  telemetry.DeployStatus,
+		MetricValue: "SUCCESS",
+		Step:        "1",
+	}
+	db.Instance.Save(&testData)
+	retrieved := &telemetry.Telemetry{}
+	db.Instance.First(retrieved)
+	assert.Equal(t, "SUCCESS", retrieved.MetricValue)
+	sqlDb, _ := db.Instance.DB()
+	sqlDb.Close()
+	os.Remove(DB_FILENAME)
 }
 
 // TestMain wraps the tests.  Setup is done before the call to m.Run() and any

--- a/server/telemetry/enums.go
+++ b/server/telemetry/enums.go
@@ -1,0 +1,26 @@
+package telemetry
+
+import "database/sql/driver"
+
+type DeploymentMetric string
+
+const (
+	StartTime              DeploymentMetric = "StartTime"
+	EndTime                DeploymentMetric = "EndTime"
+	CustomerSubscriptionID DeploymentMetric = "CustomerSubscriptionID"
+	Region                 DeploymentMetric = "Region"
+	AccessType             DeploymentMetric = "AccessType"
+	DeployStatus           DeploymentMetric = "DeployStatus"
+	Errors                 DeploymentMetric = "Errors"
+	Retries                DeploymentMetric = "Retries"
+)
+
+// Allow GORM to store the string value of DeploymentMetric
+func (u *DeploymentMetric) Scan(value interface{}) error {
+	*u = DeploymentMetric(value.(string))
+	return nil
+}
+
+func (u DeploymentMetric) Value() (driver.Value, error) {
+	return string(u), nil
+}

--- a/server/telemetry/model.go
+++ b/server/telemetry/model.go
@@ -13,6 +13,7 @@ type Telemetry struct {
 	Step        string
 }
 
+// Getter Setters for each DeploymentMetric starting with DeploymentStatus - can be used for AAP-10177.
 func SetDeploymentStatus(db *gorm.DB, telemetry *Telemetry, status string) {
 	telemetry.MetricName = DeployStatus
 	telemetry.MetricValue = status

--- a/server/telemetry/model.go
+++ b/server/telemetry/model.go
@@ -1,0 +1,25 @@
+package telemetry
+
+import (
+	"server/model"
+
+	"gorm.io/gorm"
+)
+
+type Telemetry struct {
+	model.BaseModel
+	MetricName  DeploymentMetric `gorm:"type:string"`
+	MetricValue string
+	Step        string
+}
+
+func SetDeploymentStatus(db *gorm.DB, telemetry *Telemetry, status string) {
+	telemetry.MetricName = DeployStatus
+	telemetry.MetricValue = status
+	db.Save(&telemetry)
+}
+
+func DeploymentStatus(db *gorm.DB) *gorm.DB {
+
+	return db.Where("MetricName = ?", DeployStatus)
+}


### PR DESCRIPTION
# Description
<!-- Describe the changes introduced in the PR below, include rationale and technical/design decisions -->
This PR is to create a new table in the InstallerStore DB called telemetries. This table will be responsible for holding all data metrics that are required to be published on Amplitude dashboard via Segment for BU reporting. 

<!-- Uncomment following block and add links (surrounded by < and > ) to any resources or documents if those might help explain the PR -->
<!--
## Links
<...>
-->

## PR task checklist
<!-- Mark tasks done by putting x inside [ ]. If any task in the checklist does not apply, mark the task done AND surround the text with ~ ~ (tilda) to strike it out -->
- [x] I have performed a self-review of my code
- [x] I have followed code style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~[ ] I have made corresponding changes to the documentation~
- [x] I have added thorough tests
- [x] I have had a successful deployment with the changes in this PR


# Ticket
<!--- Put JIRA story/task/bug number in the link below or remove the next line and uncomment one below it. -->
https://issues.redhat.com/browse/AAP-10173
<!-- This PR does not need a corresponding JIRA item. -->

# Testing
<!-- Describe the testing process in set of steps. If testing is not applicable, remove the steps and add a statement explaining why testing isn't applicable. -->
1. Pull down the PR.
2. Create a new deployment using the installerincluded branch of aap-azurerm repo.
3. Once the Installer starts, go to Azure portal and enter the deploymentEngineGroup.
4. Install SQLite, connect to the Installer DB (sqlite3 /installerstore/installer.db) and check to see if the table exists.