### PR TITLE
Add status for steps that are pending restart

### DIFF
--- a/ui/src/app/Deployment/DeploymentSteps/StepStatus.tsx
+++ b/ui/src/app/Deployment/DeploymentSteps/StepStatus.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { FlexItem, Icon, TextVariants, Text, Tooltip, Flex } from '@patternfly/react-core';
 import CheckCircleIcon from '@patternfly/react-icons/dist/esm/icons/check-circle-icon';
 import ExclamationCircleIcon from '@patternfly/react-icons/dist/esm/icons/exclamation-circle-icon';
+import HistoryIcon from '@patternfly/react-icons/dist/esm/icons/history-icon';
 import { DeploymentStepStatusData, StepStatuses } from '../../apis/types';
 import { ErrorInfoPopover } from '../../ErrorInfo/ErrorInfo';
 
@@ -14,6 +15,7 @@ export const StepStatus = ({ stepStatusData }: IStepStatusProps) => {
   const hasStarted = (stepStatusData.status === StepStatuses.STARTED)
   const hasSucceeded = (stepStatusData.status === StepStatuses.SUCCEEDED)
   const hasFailed = (stepStatusData.status === StepStatuses.FAILED)
+  const hasRestartPending = (stepStatusData.status === StepStatuses.RESTART_PENDING)
   const hasBeenCanceled = (stepStatusData.status === StepStatuses.CANCELED)
 
   return (
@@ -22,10 +24,11 @@ export const StepStatus = ({ stepStatusData }: IStepStatusProps) => {
         { (hasSucceeded || hasFailed) && <Text className='timeTaken' component={TextVariants.h5}>({stepStatusData.duration})</Text> }
       </FlexItem>
       <FlexItem>
-        { hasFailed && <Text className='attempt' component={TextVariants.h5}>({stepStatusData.attempts} attempts)</Text> }
+        { (hasFailed || hasRestartPending) && <Text className='attempt' component={TextVariants.h5}>({stepStatusData.attempts} { stepStatusData.attempts === 1 ? 'attempt' : 'attempts' })</Text> }
       </FlexItem>
       <FlexItem className="statusTooltip" align={{ default: 'alignRight' }}>
         { hasBeenCanceled && <Tooltip removeFindDomNode={true} content={<div>{"Cancelled"}</div>}><Icon className='icon1' status="warning"><ExclamationCircleIcon /></Icon></Tooltip> }
+        { hasRestartPending && <Tooltip removeFindDomNode={true} content={<div>{"Restart pending"}</div>}><Icon className='icon1' status="warning"><HistoryIcon /></Icon></Tooltip> }
         { hasSucceeded && <Tooltip removeFindDomNode={true} content={<div>Success</div>}><Icon className='icon1' status="success"><CheckCircleIcon /></Icon></Tooltip> }
         { hasFailed && <ErrorInfoPopover stepStatusData={stepStatusData}></ErrorInfoPopover> }
         { hasStarted && <Icon className='icon1' isInProgress={true}><CheckCircleIcon /></Icon> }

--- a/ui/src/app/apis/types.tsx
+++ b/ui/src/app/apis/types.tsx
@@ -3,6 +3,7 @@ export enum StepStatuses {
 	STARTED,
 	SUCCEEDED,
 	FAILED,
+	RESTART_PENDING,
 	CANCELED
 }
 
@@ -32,6 +33,8 @@ export class DeploymentStepStatusData {
 					this.status = StepStatuses.STARTED
 					break
 				case "Restart":  // step marked restart was previously failed
+					this.status = StepStatuses.RESTART_PENDING
+					break
 				case "Failed":
 				case "PermanentlyFailed":
 				case "RestartTimedOut":


### PR DESCRIPTION
This PR adds support for handling "Restart" status of a step(step with this status has failed and user has clicked on "Restart" button) and adds a new visual representation for restarted step. 
Before this PR, steps that have failed and were marked for restart(by user clicking on restart button) were still handled as failed by the UI which resulted in having the the "Restart" button shown until the step started executing again. This situation is caused by the a limitation of the engine which can start steps in parallel, however, it does not support restarting failed steps until **ALL** steps started in parallel finished running.

Below is the screenshot of a step that has been marked for restart:
![image](https://user-images.githubusercontent.com/93541722/228082456-2588ad4f-073d-4105-9fc8-ea42ae8b3807.png)

The tool tip when hovering over the icon says "Restart pending".