### PR TITLE
Increase execution count when execution marked for restart

### DIFF
--- a/server/config/environment.go
+++ b/server/config/environment.go
@@ -46,7 +46,7 @@ func GetEnvironment() envVars {
 	environment.ENGINE_END_WAIT = 900     // 15 minutes wait before server exits after its done
 	environment.ENGINE_RETRY_WAIT = 1800  // 30 minutes wait for a step to be restarted
 	environment.ENGINE_MAX_RUNTIME = 7200 // 2 hours max run time for everything (including restarts)
-	environment.EXECUTION_MAX_RETRY = 3
+	environment.EXECUTION_MAX_RETRY = 10  // 10 executions in total allowed
 	environment.DB_PATH = "/installerstore/installer.db"
 	environment.TEMPLATE_PATH = "/installerstore/templates"
 	environment.AZURE_POLLING_FREQ_SECONDS = 5
@@ -132,55 +132,61 @@ func GetEnvironment() envVars {
 		environment.TEMPLATE_PATH = templatePath
 	}
 
-	engineEndWait, err := strconv.ParseInt(env.Get("ENGINE_END_WAIT", "0"), 10, 64)
+	// using empty string as default to force error condition and use of default when env variable not set
+	engineEndWait, err := strconv.ParseInt(env.Get("ENGINE_END_WAIT", ""), 10, 64)
 	if err != nil {
-		log.Warnf("ENGINE_END_WAIT environment variable is not a number, will use default of %d", environment.ENGINE_END_WAIT)
+		log.Warnf("ENGINE_END_WAIT environment variable is not set or is not a number, will use default: %d", environment.ENGINE_END_WAIT)
 	} else if engineEndWait != 0 {
 		environment.ENGINE_END_WAIT = engineEndWait
 	}
 
-	engineMaxRunTime, err := strconv.ParseInt(env.Get("ENGINE_MAX_RUNTIME", "0"), 10, 64)
+	// using empty string as default to force error condition and use of default when env variable not set
+	engineMaxRunTime, err := strconv.ParseInt(env.Get("ENGINE_MAX_RUNTIME", ""), 10, 64)
 	if err != nil {
-		log.Warnf("ENGINE_MAX_RUNTIME environment variable is not a number, will use default of %d", environment.ENGINE_MAX_RUNTIME)
+		log.Warnf("ENGINE_MAX_RUNTIME environment variable is not set or is not a number, will use default: %d", environment.ENGINE_MAX_RUNTIME)
 	} else if engineMaxRunTime != 0 {
 		environment.ENGINE_MAX_RUNTIME = engineMaxRunTime
 	}
 
-	engineRetryWait, err := strconv.ParseInt(env.Get("ENGINE_RETRY_WAIT", "0"), 10, 64)
+	// using empty string as default to force error condition and use of default when env variable not set
+	engineRetryWait, err := strconv.ParseInt(env.Get("ENGINE_RETRY_WAIT", ""), 10, 64)
 	if err != nil {
-		log.Warnf("ENGINE_RETRY_WAIT environment variable is not a number, will use default of %d", environment.ENGINE_RETRY_WAIT)
+		log.Warnf("ENGINE_RETRY_WAIT environment variable is not set or is not a number, will use default: %d", environment.ENGINE_RETRY_WAIT)
 	} else if engineMaxRunTime != 0 {
 		environment.ENGINE_RETRY_WAIT = engineRetryWait
 	}
 
-	executionMaxRetry, err := strconv.ParseInt(env.Get("EXECUTION_MAX_RETRY", "0"), 10, 32)
+	// using empty string as default to force error condition and use of default when env variable not set
+	executionMaxRetry, err := strconv.ParseInt(env.Get("EXECUTION_MAX_RETRY", ""), 10, 32)
 	if err != nil {
-		log.Warnf("EXECUTION_MAX_RETRY environment variable is not a number, will use default of %d", environment.EXECUTION_MAX_RETRY)
+		log.Warnf("EXECUTION_MAX_RETRY environment variable is not set or is not a number, will use default: %d", environment.EXECUTION_MAX_RETRY)
 	} else {
 		environment.EXECUTION_MAX_RETRY = int(executionMaxRetry)
 	}
 
-	azurePollingFreq, err := strconv.ParseInt(env.Get("AZURE_POLLING_FREQ_SECONDS", "0"), 10, 32)
+	// using empty string as default to force error condition and use of default when env variable not set
+	azurePollingFreq, err := strconv.ParseInt(env.Get("AZURE_POLLING_FREQ_SECONDS", ""), 10, 32)
 	if err != nil {
-		log.Warnf("AZURE_POLLING_FREQ_SECONDS environment variable is not a number, will use default of %d", environment.AZURE_POLLING_FREQ_SECONDS)
+		log.Warnf("AZURE_POLLING_FREQ_SECONDS environment variable is not set or is not a number, will use default: %d", environment.AZURE_POLLING_FREQ_SECONDS)
 	} else if azurePollingFreq > 1 {
 		environment.AZURE_POLLING_FREQ_SECONDS = int(azurePollingFreq)
 	}
 
 	autoRetry, err := strconv.ParseBool(env.Get("AUTO_RETRY", "false"))
 	if err != nil {
-		log.Warnf("AUTO_RETRY has unrecognized value, please set to true or false.  Using default: %t", environment.AUTO_RETRY)
+		log.Warnf("AUTO_RETRY has unrecognized value, please set to true or false. Using default: %t", environment.AUTO_RETRY)
 	} else {
 		environment.AUTO_RETRY = autoRetry
 	}
 
-	autoRetryDelay, err := strconv.ParseInt(env.Get("AUTO_RETRY_DELAY", "0"), 10, 32)
+	// using empty string as default to force error condition and use of default when env variable not set
+	autoRetryDelay, err := strconv.ParseInt(env.Get("AUTO_RETRY_DELAY", ""), 10, 32)
 	if err != nil {
-		log.Warnf("AUTO_RETRY_DELAY environment variable is not a number, will use default of %d", environment.AUTO_RETRY_DELAY)
+		log.Warnf("AUTO_RETRY_DELAY environment variable is not set or is not a number, will use default: %d", environment.AUTO_RETRY_DELAY)
 	} else if autoRetryDelay > 1 {
 		if autoRetryDelay > int64(environment.ENGINE_RETRY_WAIT) {
 			maxAutoRetryDelay := environment.ENGINE_RETRY_WAIT / 2
-			log.Warnf("AUTO_RETRY_DELAY cannot exceed ENGINE_RETRY_WAIT, setting to %d", maxAutoRetryDelay)
+			log.Warnf("AUTO_RETRY_DELAY cannot exceed ENGINE_RETRY_WAIT, setting to: %d", maxAutoRetryDelay)
 			environment.AUTO_RETRY_DELAY = int(maxAutoRetryDelay)
 		} else {
 			environment.AUTO_RETRY_DELAY = int(autoRetryDelay)
@@ -189,7 +195,7 @@ func GetEnvironment() envVars {
 
 	saveContainer, err := strconv.ParseBool(env.Get("SAVE_CONTAINER", "false"))
 	if err != nil {
-		log.Warnf("SAVE_CONTAINER has unrecognized value, please set to true or false.  Using default: %t", environment.SAVE_CONTAINER)
+		log.Warnf("SAVE_CONTAINER has unrecognized value, please set to true or false. Using default: %t", environment.SAVE_CONTAINER)
 	} else {
 		environment.SAVE_CONTAINER = saveContainer
 	}

--- a/server/engine/engine.go
+++ b/server/engine/engine.go
@@ -76,9 +76,9 @@ func (engine *Engine) startDeploymentExecutions() {
 				// Step to restart, mark as seen and start
 				latestExecution.Status = model.Restarted
 				engine.database.Instance.Save(&latestExecution)
-				newExecution := &model.Execution{}
-				engine.startExecution(step, newExecution, &executionWaitGroup)
-				currentExecutions[stepIndex] = newExecution
+				newExecution := model.Execution{}
+				engine.startExecution(step, &newExecution, &executionWaitGroup)
+				currentExecutions[stepIndex] = &newExecution
 			case model.Succeeded, model.Canceled:
 				continue
 			}
@@ -94,15 +94,19 @@ func (engine *Engine) startDeploymentExecutions() {
 			// first check all executions for those that can't be restarted anymore
 			terminateMainLoop := false
 			for _, execution := range currentExecutions {
-				if execution != nil && execution.Status == model.Canceled {
+				if execution == nil { // skip over null elements
+					continue
+				}
+				if execution.Status == model.Canceled {
 					// cancelled execution means the whole process will be cancelled
 					log.Warn("Found cancelled execution.")
 					terminateMainLoop = true
 					break
 				}
-				if execution != nil && execution.Status != model.Succeeded && execution.Status != model.Canceled &&
-					int(engine.countStepExecutions(execution.StepID)) >= engine.maxExecutionRestarts {
-					log.Error("Found failed deployment step that can not be restarted again.")
+				executionsCount := engine.countStepExecutions(execution.StepID)
+				if execution.Status != model.Succeeded && execution.Status != model.Canceled &&
+					(executionsCount >= int64(engine.maxExecutionRestarts)) {
+					log.Errorf("Found failed deployment step that can not be restarted because it had %d executions. Maximum is %d.", executionsCount, engine.maxExecutionRestarts)
 					terminateMainLoop = true
 					execution.Status = model.PermanentlyFailed
 					engine.database.Instance.Save(execution)
@@ -195,6 +199,7 @@ func (engine *Engine) GetLatestExecution(step model.Step) model.Execution {
 func (engine *Engine) startExecution(step model.Step, execution *model.Execution, waitGroup *sync.WaitGroup) {
 	execution.Status = model.Started
 	execution.StepID = step.ID
+	engine.database.Instance.Save(&execution)
 
 	// Run in goroutine to allow parallel deployments
 	log.Infof("Starting execution of deployment step [%s]...", step.Name)

--- a/server/engine/engine.go
+++ b/server/engine/engine.go
@@ -77,6 +77,8 @@ func (engine *Engine) startDeploymentExecutions() {
 				latestExecution.Status = model.Restarted
 				engine.database.Instance.Save(&latestExecution)
 				newExecution := &model.Execution{}
+				// set execution count to be one bigger than last execution
+				newExecution.ExecutionCount = latestExecution.ExecutionCount + 1
 				engine.startExecution(step, newExecution, &executionWaitGroup)
 				currentExecutions[stepIndex] = newExecution
 			case model.Succeeded, model.Canceled:

--- a/server/model/model.go
+++ b/server/model/model.go
@@ -48,7 +48,6 @@ type Execution struct {
 	Duration          string          `json:"duration"`
 	CorrelationID     string          `json:"correlationId"`
 	ResumeToken       string          `json:"-"`
-	ExecutionCount    int             `json:"executionCount"`
 }
 
 type Status struct {
@@ -72,7 +71,6 @@ type Telemetry struct {
 }
 
 func UpdateExecution(execution *Execution, result *DeploymentResult, errJson string) {
-	execution.ExecutionCount++
 	execution.ResumeToken = ""
 
 	if result != nil {

--- a/server/model/model_test.go
+++ b/server/model/model_test.go
@@ -69,15 +69,13 @@ func TestDurationParsing(t *testing.T) {
 
 func TestUpdateExecution(t *testing.T) {
 	execution := model.Execution{
-		ResumeToken:    "token",
-		ExecutionCount: 0,
+		ResumeToken: "token",
 	}
 
 	// No result to check
 	model.UpdateExecution(&execution, nil, "")
 	assert.Equal(t, model.Failed, execution.Status)
 	assert.Equal(t, "", execution.ResumeToken, "Resume token should be removed")
-	assert.Equal(t, 1, execution.ExecutionCount, "Execution count should be incremented")
 	execution.ResumeToken = "token"
 	now := time.Now()
 	result := model.DeploymentResult{
@@ -92,7 +90,6 @@ func TestUpdateExecution(t *testing.T) {
 	// With result
 	model.UpdateExecution(&execution, &result, "")
 	assert.Equal(t, "", execution.ResumeToken, "Resume token should be removed")
-	assert.Equal(t, 2, execution.ExecutionCount, "Execution count should be incremented")
 	assert.Equal(t, "ID", execution.DeploymentID)
 	assert.Equal(t, model.Failed, execution.Status)
 	assert.Equal(t, "1 seconds", execution.Duration)


### PR DESCRIPTION
This PR carries the execution count from stored execution to the new one when execution is marked for restart. This has to be done because the execution starts with a fresh instance.