### PR TITLE
Fix handling timed-out step restart

### DIFF
--- a/server/handler/status.go
+++ b/server/handler/status.go
@@ -28,7 +28,7 @@ func Status(db *gorm.DB, w http.ResponseWriter, r *http.Request) {
 	status := Done
 	for _, step := range steps {
 		latestExecution := getLatestExecution(db, step)
-		if latestExecution.Status == model.PermanentlyFailed {
+		if latestExecution.Status == model.PermanentlyFailed || latestExecution.Status == model.RestartTimedOut {
 			status = Failed
 			break
 		} else if latestExecution.Status == model.Canceled {

--- a/ui/src/app/apis/types.tsx
+++ b/ui/src/app/apis/types.tsx
@@ -37,10 +37,10 @@ export class DeploymentStepStatusData {
 					this.status = StepStatuses.RESTART_PENDING
 					break
 				case "PermanentlyFailed":
+				case "RestartTimedOut":
 					this.status = StepStatuses.PERM_FAILED
 					break
 				case "Failed":
-				case "RestartTimedOut":
 					this.status = StepStatuses.FAILED
 					break
 				case "Succeeded":


### PR DESCRIPTION
This PR delivers two changes:
- UI will consider a step with status "RestartTimedOut" the same as a step that is permanently failed (it is effectively same because if the user didn't restart it, or it wasn't restarted automatically, it is permanently failed)
- the status reporting API will consider overall process as failed if it finds a step with status "RestartTimedOut

Following screenshot shows the UI after a step failed and it was not restarted in time.
![image](https://user-images.githubusercontent.com/93541722/231769118-1a150003-e660-4e0d-9b5c-c36217fc7a62.png)
