### PR TITLE
Move dry run execution into loop

### DIFF
--- a/scripts/build-modm.sh
+++ b/scripts/build-modm.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-mkdir ./bin
+mkdir -p ./bin
 
 # ---------------------------------------------------------------------------
 # Microsoft's marketplace offer deployment manager


### PR DESCRIPTION
I tested this as far as seeing that it did run the dry run as expected, but don't have nginx config yet so event callbacks don't work.  Also still seeing it fail to retrieve the deployment info from Azure.  I also don't see that any deployment gets created in my resource group called "deployment-driver" (404 errors).