### PR TITLE
Fix event hook data type handling + dry run execution data persistence

### DIFF
--- a/server/engine/dryrun_test.go
+++ b/server/engine/dryrun_test.go
@@ -13,13 +13,18 @@ import (
 	"gorm.io/gorm"
 )
 
-type testDryRunController struct {
+type dryRunTest struct {
 	db   *gorm.DB
 	done chan struct{}
 }
 
-func newTestDryRunController() *testDryRunController {
+func newDryRunTest() *dryRunTest {
 	database := persistence.NewNoCacheInMemoryDb()
+	db, err := database.Instance.DB()
+	if err != nil {
+		log.Fatal(err)
+	}
+	db.SetMaxOpenConns(1)
 	database.Instance = database.Instance.Session(&gorm.Session{NewDB: true})
 
 	engine := &Engine{
@@ -27,14 +32,14 @@ func newTestDryRunController() *testDryRunController {
 	}
 	engine.addDryRunStep(nil, nil, 0)
 
-	return &testDryRunController{
+	return &dryRunTest{
 		db:   database.Instance,
 		done: make(chan struct{}),
 	}
 }
 
 func Test_dryRunController_getStep(t *testing.T) {
-	test := newTestDryRunController()
+	test := newDryRunTest()
 
 	controller := &dryRunController{
 		db: test.db,
@@ -48,8 +53,8 @@ func Test_dryRunController_getStep(t *testing.T) {
 	assert.Equal(t, model.DryRunStepName, step.Name)
 }
 
-func Test_dryRunController_getStep_fetches_association_with_operationId(t *testing.T) {
-	test := newTestDryRunController()
+func Test_dryRunController_getStep_fetches_association_with_dryrun_id(t *testing.T) {
+	test := newDryRunTest()
 
 	controller := &dryRunController{
 		db: test.db,
@@ -60,12 +65,14 @@ func Test_dryRunController_getStep_fetches_association_with_operationId(t *testi
 	assert.Equal(t, 0, len(step.Executions))
 
 	// add execution step to ensure that's returned with the step
-	operationId := uuid.MustParse("d42e3b3d-c54e-4408-aa65-b9c98d137a72")
+	id := uuid.MustParse("d42e3b3d-c54e-4408-aa65-b9c98d137a72")
 	execution := model.Execution{
-		StepID:        step.ID,
-		DeploymentID:  "1",
-		Status:        model.Started,
-		CorrelationID: operationId.String(),
+		StepID: step.ID,
+		Status: model.Started,
+		DryRunExecution: &model.DryRunExecution{
+			Id:           id.String(),
+			DeploymentId: 1,
+		},
 	}
 
 	test.db.Save(&execution)
@@ -74,69 +81,72 @@ func Test_dryRunController_getStep_fetches_association_with_operationId(t *testi
 	assert.Equal(t, 1, len(step.Executions))
 
 	assert.NoError(t, err)
-	assert.Equal(t, step.Executions[0].CorrelationID, operationId.String())
+	assert.Equal(t, step.Executions[0].DryRunExecution.Id, id.String())
 	assert.Equal(t, step.Executions[0].ID, uint(1))
 }
 
-func Test_dryRunController_update(t *testing.T) {
-	test := newTestDryRunController()
+func Test_dryRunController_update_succeeds_with_execution_by_dryrun_id(t *testing.T) {
+	test := newDryRunTest()
+
+	dryRunInstanceId := uuid.MustParse("f181f551-5d17-4ab4-bbcb-407d47b63f77")
+
 	controller := &dryRunController{
 		db: test.db,
 	}
 
-	operationId := uuid.MustParse("f181f551-5d17-4ab4-bbcb-407d47b63f77")
+	//setup execution with the dryrun id
+	controller.create(1, &sdk.InvokeDryRunResponse{
+		Id:     dryRunInstanceId,
+		Status: sdk.StatusScheduled.String(),
+	}, nil)
+
+	//simulate the event hook message
 	message := &sdk.EventHookMessage{
 		Id:     uuid.New(),
+		Type:   string(sdk.EventTypeDryRunCompleted),
 		Status: sdk.StatusSuccess.String(),
-		Data: sdk.DeploymentEventData{
+		Data: sdk.DryRunEventData{
 			DeploymentId: 1,
-			OperationId:  operationId,
+			OperationId:  dryRunInstanceId,
 		},
 	}
 
+	//should succeed to update
 	err := controller.update(message)
 	assert.NoError(t, err)
 
-	step, err := controller.getStep()
-	assert.NoError(t, err)
-
+	step, _ := controller.getStep()
 	assert.Equal(t, 1, len(step.Executions))
-	assert.Equal(t, operationId.String(), step.Executions[0].CorrelationID)
-
-	// update to be ide
+	assert.Equal(t, dryRunInstanceId.String(), step.Executions[0].DryRunExecution.Id)
 }
 
 func Test_dryRunController_update_should_be_idempotent(t *testing.T) {
-	test := newTestDryRunController()
+	test := newDryRunTest()
 	controller := &dryRunController{
 		db: test.db,
 	}
 
-	operationId := uuid.MustParse("f181f551-5d17-4ab4-bbcb-407d47b63f77")
+	dryRunInstanceId := uuid.MustParse("f181f551-5d17-4ab4-bbcb-407d47b63f77")
 	message := &sdk.EventHookMessage{
 		Id:     uuid.New(),
+		Type:   string(sdk.EventTypeDryRunCompleted),
 		Status: sdk.StatusSuccess.String(),
-		Data: sdk.DeploymentEventData{
+		Data: sdk.DryRunEventData{
 			DeploymentId: 1,
-			OperationId:  operationId,
+			OperationId:  dryRunInstanceId,
 		},
 	}
 	err := controller.update(message)
-	assert.NoError(t, err)
-
-	err = controller.update(message)
 	assert.NoError(t, err)
 
 	step, _ := controller.getStep()
 
 	assert.Equal(t, 1, len(step.Executions))
-	assert.Equal(t, operationId.String(), step.Executions[0].CorrelationID)
-
-	// update to be ide
+	assert.Equal(t, dryRunInstanceId.String(), step.Executions[0].DryRunExecution.Id)
 }
 
-func Test_dryRunController_dryRunDone(t *testing.T) {
-	test := newTestDryRunController()
+func Test_dryRunController_Done(t *testing.T) {
+	test := newDryRunTest()
 
 	controller := &dryRunController{
 		db:   test.db,
@@ -153,9 +163,10 @@ func Test_dryRunController_dryRunDone(t *testing.T) {
 				OperationId:  operationId,
 			},
 		}
-		time.Sleep(2 * time.Second)
-		controller.DryRunDone(message)
+		time.Sleep(1 * time.Second)
+		controller.Done(message)
 	}()
+
 	log.Print("waiting for done")
 	<-test.done
 	log.Print("dryRunDone called")

--- a/server/go.mod
+++ b/server/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/google/uuid v1.3.0
 	github.com/gorilla/mux v1.8.0
 	github.com/gorilla/sessions v1.2.1
-	github.com/microsoft/commercial-marketplace-offer-deploy/sdk v1.0.0
+	github.com/microsoft/commercial-marketplace-offer-deploy/sdk v1.0.1
 	github.com/segmentio/analytics-go/v3 v3.2.1
 	github.com/sirupsen/logrus v1.9.0
 	github.com/stretchr/testify v1.8.2

--- a/server/go.sum
+++ b/server/go.sum
@@ -58,8 +58,8 @@ github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+
 github.com/mattn/go-sqlite3 v1.14.15/go.mod h1:2eHXhiwb8IkHr+BDWZGa96P6+rkvnG63S2DGjv9HUNg=
 github.com/mattn/go-sqlite3 v1.14.16 h1:yOQRA0RpS5PFz/oikGwBEqvAWhWg5ufRz4ETLjwpU1Y=
 github.com/mattn/go-sqlite3 v1.14.16/go.mod h1:2eHXhiwb8IkHr+BDWZGa96P6+rkvnG63S2DGjv9HUNg=
-github.com/microsoft/commercial-marketplace-offer-deploy/sdk v1.0.0 h1:JSh654VNLT5ADU9ZELLE/Eje04gZjTn4Ryu3bfBZVkQ=
-github.com/microsoft/commercial-marketplace-offer-deploy/sdk v1.0.0/go.mod h1:R9U5eUJiu9FvqEPwYJJQYuYyul9yrpxDYBzGUGp+mNM=
+github.com/microsoft/commercial-marketplace-offer-deploy/sdk v1.0.1 h1:qZr00W7Sr6/c9TebzdOSkTem4y2BB8FbrjjCLD0y220=
+github.com/microsoft/commercial-marketplace-offer-deploy/sdk v1.0.1/go.mod h1:R9U5eUJiu9FvqEPwYJJQYuYyul9yrpxDYBzGUGp+mNM=
 github.com/microsoft/go-mssqldb v0.17.0 h1:Fto83dMZPnYv1Zwx5vHHxpNraeEaUlQ/hhHLgZiaenE=
 github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyuac5Z2hdY=
 github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=

--- a/server/handler/eventhook.go
+++ b/server/handler/eventhook.go
@@ -29,7 +29,7 @@ func EventHook(db *gorm.DB, w http.ResponseWriter, r *http.Request) {
 	if handler.isDryRunCompleted(message) {
 		log.Debugf("Received event hook message: %+v", message)
 		controller := engine.DryRunControllerInstance()
-		controller.DryRunDone(message)
+		controller.Done(message)
 	}
 
 	// TODO: decide the correct response payload

--- a/server/model/model.go
+++ b/server/model/model.go
@@ -5,6 +5,7 @@ import (
 
 	"time"
 
+	"github.com/microsoft/commercial-marketplace-offer-deploy/sdk"
 	log "github.com/sirupsen/logrus"
 	"gorm.io/datatypes"
 	_ "gorm.io/driver/sqlite"
@@ -50,6 +51,19 @@ type Execution struct {
 	Duration          string          `json:"duration"`
 	CorrelationID     string          `json:"correlationId"`
 	ResumeToken       string          `json:"-"`
+
+	// the execution data of a dry run (received from modm)
+	DryRunExecution *DryRunExecution `json:"dryRunExecution" gorm:"json"`
+}
+
+type DryRunExecution struct { // the execution instance of the dry run (received from modm)
+	Id string `json:"operationId"`
+	// momd deploymentId, different than the DeploymentID in Execution
+	DeploymentId uint   `json:"deploymentId"`
+	Status       string `json:"status"`
+
+	// the errors captured from the dry run (received from modm) if the status (on this struct) is failed
+	Error *sdk.DryRunErrorResponse `json:"error"`
 }
 
 type Status struct {


### PR DESCRIPTION
This update does the following:

- fixes deployment name (shouldn't contain forward slash)
- adds dry run execution field to Execution to track dry run specific results
- update to use method on sdk.EventHookMessage to get dry run data 
- updating to v1.0.1 with latest fixes in MODM