### PR TITLE
Support building MODM container image and running MODM in two containers

### DIFF
--- a/Dockerfile.deployment-driver
+++ b/Dockerfile.deployment-driver
@@ -13,17 +13,11 @@ RUN yum -y --repo ubi-9-appstream-rpms install socat && \
   unzip -qoj acme.zip acme.sh-${ACME_RELEASE_TAG}/acme.sh -d . && rm acme.zip && \
   echo "ACME=${ACME_RELEASE_TAG}" >> versions && echo "DRIVER=${DRIVER_RELEASE_TAG}" >> versions
 
-# AZ cli for local development purposes, can be removed later if desired
-RUN rpm --import https://packages.microsoft.com/keys/microsoft.asc && \
-  dnf install -y https://packages.microsoft.com/config/rhel/9.0/packages-microsoft-prod.rpm && \
-  dnf install -y azure-cli
-
-
 ADD ["nginx", "/etc/nginx/"]
-ADD ["start.sh", "build/server", "build/apiserver", "build/operator", "./"]
+ADD ["start.sh", "build/server", "./"]
 ADD ["build/public", "/var/www/aapinstaller/public"]
 
-RUN chmod +x ./acme.sh ./server ./apiserver ./operator && chmod +x ./start.sh
+RUN chmod +x ./acme.sh ./server ./start.sh
 
 VOLUME [ "/installerstore" ]
 

--- a/Dockerfile.modm
+++ b/Dockerfile.modm
@@ -1,0 +1,13 @@
+FROM registry.access.redhat.com/ubi9/ubi
+
+USER root
+
+WORKDIR /opt/app-root/src/
+
+ADD ["start_modm.sh", "build/apiserver", "build/operator", "./"]
+
+RUN chmod +x ./apiserver ./operator ./start_modm.sh
+
+VOLUME [ "/installerstore" ]
+
+ENTRYPOINT ["./start_modm.sh"]

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ IMAGE_TAG ?= latest
 MODM_REPOSITORY_NAME := commercial-marketplace-offer-deploy
 MODM_BUILD_DIR := build/${MODM_REPOSITORY_NAME}
 MODM_REPOSITORY_URL := https://github.com/microsoft/${MODM_REPOSITORY_NAME}.git
-MODM_VERSION := v1.2.0
+MODM_VERSION := v1.3.0
 MODM_IMAGE_NAME ?= modm
 MODM_IMAGE_TAG ?= ${MODM_VERSION}
 

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,9 @@ IMAGE_TAG ?= latest
 MODM_REPOSITORY_NAME := commercial-marketplace-offer-deploy
 MODM_BUILD_DIR := build/${MODM_REPOSITORY_NAME}
 MODM_REPOSITORY_URL := https://github.com/microsoft/${MODM_REPOSITORY_NAME}.git
-MODM_VERSION := v1.1.2
+MODM_VERSION := v1.2.0
+MODM_IMAGE_NAME ?= modm
+MODM_IMAGE_TAG ?= ${MODM_VERSION}
 
 .PHONY: clean assemble save-image push-image check-credentials build-server build-web-ui
 
@@ -25,11 +27,11 @@ endif
 ifndef CONTAINER_REGISTRY_PASSWORD
 	$(error Environment variable CONTAINER_REGISTRY_PASSWORD is not set)
 endif
+
+resolve-registry:
 ifndef CONTAINER_REGISTRY_DEFAULT_SERVER
 	$(error Environment variable CONTAINER_REGISTRY_DEFAULT_SERVER is not set)
 endif
-
-resolve-registry:
 ifndef CONTAINER_REGISTRY_NAMESPACE
 CONTAINER_REGISTRY_NAMESPACE := ${CONTAINER_REGISTRY_DEFAULT_NAMESPACE}
 endif
@@ -37,10 +39,17 @@ ifndef CONTAINER_REGISTRY
 CONTAINER_REGISTRY := ${CONTAINER_REGISTRY_DEFAULT_SERVER}/${CONTAINER_REGISTRY_NAMESPACE}
 endif
 
-assemble: clean resolve-registry build-server build-web-ui build-modm
+assemble: clean resolve-registry build-server build-web-ui build-modm assemble-deployment-driver assemble-modm
+
+assemble-deployment-driver: clean resolve-registry build-server build-web-ui
 	@echo "Building docker image: ${CONTAINER_REGISTRY}/${IMAGE_NAME}:${IMAGE_TAG}"
-	docker build --build-arg DRIVER_RELEASE_TAG=${DRIVER_RELEASE_TAG} -t ${CONTAINER_REGISTRY}/${IMAGE_NAME}:${IMAGE_TAG} .
+	docker build -f ./Dockerfile.deployment-driver --build-arg DRIVER_RELEASE_TAG=${DRIVER_RELEASE_TAG} -t ${CONTAINER_REGISTRY}/${IMAGE_NAME}:${IMAGE_TAG} .
 	docker tag ${CONTAINER_REGISTRY}/${IMAGE_NAME}:${IMAGE_TAG} ${CONTAINER_REGISTRY}/${IMAGE_NAME}:latest
+
+assemble-modm: clean resolve-registry build-modm
+	@echo "Building docker image: ${CONTAINER_REGISTRY}/${MODM_IMAGE_NAME}:${MODM_IMAGE_TAG}"
+	docker build -f ./Dockerfile.modm -t ${CONTAINER_REGISTRY}/${MODM_IMAGE_NAME}:${MODM_IMAGE_TAG} .
+	docker tag ${CONTAINER_REGISTRY}/${MODM_IMAGE_NAME}:${MODM_IMAGE_TAG} ${CONTAINER_REGISTRY}/${MODM_IMAGE_NAME}:latest
 
 save-image: assemble
 	@echo "Saving docker image: ${IMAGE_NAME}:${IMAGE_TAG} to tar.gz archive..."
@@ -56,8 +65,10 @@ logout-from-registry:
 	docker logout ${CONTAINER_REGISTRY}
 
 push-image: assemble
-	@echo "Pushing image to registry: ${CONTAINER_REGISTRY}/${IMAGE_NAME}:${IMAGE_TAG}"
+	@echo "Pushing deployment driver image to registry: ${CONTAINER_REGISTRY}/${IMAGE_NAME}:${IMAGE_TAG}"
 	docker push --all-tags ${CONTAINER_REGISTRY}/${IMAGE_NAME}
+	@echo "Pushing MODM image to registry: ${CONTAINER_REGISTRY}/${MODM_IMAGE_NAME}:${MODM_IMAGE_TAG}"
+	docker push --all-tags ${CONTAINER_REGISTRY}/${MODM_IMAGE_NAME}
 
 build-server:
 	@echo "Building installer server"

--- a/nginx/reverseproxy/deployment_driver.conf
+++ b/nginx/reverseproxy/deployment_driver.conf
@@ -1,4 +1,4 @@
 location /api/ {
-  proxy_pass http://127.0.0.1:9090/;
+  proxy_pass http://localhost:9090/;
   include    nginxconfig.io/proxy.conf;
 }

--- a/nginx/reverseproxy/modm_api.conf
+++ b/nginx/reverseproxy/modm_api.conf
@@ -1,4 +1,4 @@
 location /modm/ {
-  proxy_pass http://127.0.0.1:8080/;
+  proxy_pass http://localhost:8080/;
   include    nginxconfig.io/proxy.conf;
 }

--- a/server/config/environment.go
+++ b/server/config/environment.go
@@ -39,6 +39,7 @@ type envVars struct {
 	WEB_HOOK_API_KEY           string
 	WEB_HOOK_CALLBACK_URL      string
 	LOG_PATH                   string
+	LOG_LEVEL                  string
 }
 
 var (
@@ -68,6 +69,7 @@ func GetEnvironment() envVars {
 	environment.SAVE_CONTAINER = false
 	environment.START_TIME = time.Now().Format(time.RFC3339)
 	environment.LOG_PATH = "/installerstore/engine.txt"
+	environment.LOG_LEVEL = "info"
 
 	// TODO: need to set this to a real value that's not hardcoded
 	environment.WEB_HOOK_API_KEY = "6P7Q9SATBVDWEXGZH2J4M5N6Q8"
@@ -149,6 +151,11 @@ func GetEnvironment() envVars {
 	logPath := env.Get("LOG_PATH")
 	if len(logPath) > 0 {
 		environment.LOG_PATH = logPath
+	}
+
+	logLevel := env.Get("LOG_LEVEL")
+	if len(logLevel) > 0 {
+		environment.LOG_LEVEL = logLevel
 	}
 
 	templatePath := env.Get("TEMPLATE_PATH")

--- a/start.sh
+++ b/start.sh
@@ -29,14 +29,6 @@ stop() {
     kill -TERM "$SERVER_PID" 2> /dev/null
     wait "$SERVER_PID"
   fi
-  if [[ -n "$APISERVER_PID" ]]; then
-    kill -TERM "$APISERVER_PID" 2> /dev/null
-    wait "$APISERVER_PID"
-  fi
-  if [[ -n "$OPERATOR_PID" ]]; then
-    kill -TERM "$OPERATOR_PID" 2> /dev/null
-    wait "$OPERATOR_PID"
-  fi
   nginx -s quit
   waitForNginxToStop
 }
@@ -191,10 +183,6 @@ export SESSION_COOKIE_DOMAIN=${INSTALLER_DOMAIN_NAME}
 
 ./server &
 SERVER_PID=$!
-./apiserver &
-APISERVER_PID=$!
-./operator &
-OPERATOR_PID=$!
 
 NGINX_PID=$(cat /var/run/nginx.pid)
 

--- a/start_modm.sh
+++ b/start_modm.sh
@@ -13,7 +13,7 @@ elif [ "${MODM_ROLE}" == "apiserver" ]; then
   echo "Role specified to run: apiserver"
   EXECUTABLE="./apiserver"
 else
-  echo "Role specified does not match neither 'apiserver' nor 'operator'."
+  echo "Unexpected value in MODM_ROLE environment variable. Expected either 'apiserver' or 'operator', got: ${MODM_ROLE}"
   exit 1
 fi
 

--- a/start_modm.sh
+++ b/start_modm.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+# Verify that required env variables are set, only checking for variables needed by this script
+if [ -z ${MODM_ROLE} ]; then
+  echo "Environment variable MODM_ROLE not set or is empty."
+  exit 1
+fi
+
+if [ "${MODM_ROLE}" == "operator" ]; then
+  echo "Role specified to run: operator"
+  EXECUTABLE="./operator"
+elif [ "${MODM_ROLE}" == "apiserver" ]; then
+  echo "Role specified to run: apiserver"
+  EXECUTABLE="./apiserver"
+else
+  echo "Role specified does not match neither 'apiserver' nor 'operator'."
+  exit 1
+fi
+
+echo "Starting ${EXECUTABLE}..."
+${EXECUTABLE}

--- a/start_modm.sh
+++ b/start_modm.sh
@@ -17,5 +17,11 @@ else
   exit 1
 fi
 
+# start the executable in background so its PID can be stored in a file
 echo "Starting ${EXECUTABLE}..."
-${EXECUTABLE}
+${EXECUTABLE} &
+MODM_PID=$!
+
+# store PID in a file that's not in persistent volume and wait for the process to end
+echo ${MODM_PID} > /tmp/modm_process_pid
+wait -n ${MODM_PID}


### PR DESCRIPTION
This PR provides support for running MODM binaries in their own containers (from the same image) by specifying an env variable "MODM_ROLE" specifying either `apiserver` or `operator`.
Existing docker file has been renamed so we can have one for deployment driver and one for modm.
Since the containers are meant to run in Azure, the nginx config for proxy has been updated to use host name of `localhost` instead of IP address `127.0.0.1`.
Finally, Makefile expects env variable ` CONTAINER_REGISTRY_DEFAULT_SERVER` to be set in order to build images.