### PR TITLE
Change env variable for log level

### DIFF
--- a/server/config/environment.go
+++ b/server/config/environment.go
@@ -39,7 +39,7 @@ type envVars struct {
 	WEB_HOOK_API_KEY           string
 	WEB_HOOK_CALLBACK_URL      string
 	LOG_PATH                   string
-	LOG_LEVEL                  string
+	ENGINE_LOG_LEVEL           string
 }
 
 var (
@@ -69,7 +69,7 @@ func GetEnvironment() envVars {
 	environment.SAVE_CONTAINER = false
 	environment.START_TIME = time.Now().Format(time.RFC3339)
 	environment.LOG_PATH = "/installerstore/engine.txt"
-	environment.LOG_LEVEL = "info"
+	environment.ENGINE_LOG_LEVEL = "info"
 
 	// TODO: need to set this to a real value that's not hardcoded
 	environment.WEB_HOOK_API_KEY = "6P7Q9SATBVDWEXGZH2J4M5N6Q8"
@@ -153,9 +153,9 @@ func GetEnvironment() envVars {
 		environment.LOG_PATH = logPath
 	}
 
-	logLevel := env.Get("LOG_LEVEL")
+	logLevel := env.Get("ENGINE_LOG_LEVEL")
 	if len(logLevel) > 0 {
-		environment.LOG_LEVEL = logLevel
+		environment.ENGINE_LOG_LEVEL = logLevel
 	}
 
 	templatePath := env.Get("TEMPLATE_PATH")

--- a/server/config/logformat.go
+++ b/server/config/logformat.go
@@ -34,7 +34,7 @@ func ConfigureLogging() {
 	formatter.CallerPrettyfier = CallerFormattingFunc
 	log.SetFormatter(UTCTextFormatter{formatter})
 	log.SetReportCaller(true)
-	log.SetLevel(getLogLevel(GetEnvironment().LOG_LEVEL))
+	log.SetLevel(getLogLevel(GetEnvironment().ENGINE_LOG_LEVEL))
 }
 
 func getLogLevel(level string) log.Level {


### PR DESCRIPTION
Changing the env variable name from `LOG_LEVEL` to `ENGINE_LOG_LEVEL` to avoid conflict with acme.sh scrip that expect the same variable but expecting it to be an integer.