### PR TITLE
Add metric for number of logins

### DIFF
--- a/server/api/installer.go
+++ b/server/api/installer.go
@@ -72,7 +72,7 @@ func (a *Installer) configureSessionHelper() {
 
 func (a *Installer) setRouters() {
 	a.Get("/status", a.WrapHandlerWithDB(handler.Status))
-	a.Post("/login", handler.GetLoginHandler("admin", config.GetEnvironment().PASSWORD))
+	a.Post("/login", a.WrapHandlerWithDB(handler.GetLoginHandler())) // GetLoginHandler() must be executed to do its initialization
 	a.Post("/logout", handler.EnsureAuthenticated(handler.Logout))
 	a.Get("/step", handler.EnsureAuthenticated(a.WrapHandlerWithDB(handler.GetAllSteps)))
 	a.Get("/step/{id}", handler.EnsureAuthenticated(a.WrapHandlerWithDB(handler.GetStep)))

--- a/server/engine/telemetry.go
+++ b/server/engine/telemetry.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"server/config"
 	"server/model"
+	"strconv"
 	"time"
 
 	"github.com/segmentio/analytics-go/v3"
@@ -115,6 +116,22 @@ func SetFinalMetrics(db *gorm.DB) {
 	StoreMetricFromMainOutputs(db)
 	storeMetricsPerStep(db)
 
+}
+
+func UpdateLogInMetrics(db *gorm.DB) {
+	loginsCount := "1" // default value for case if no logins were recorded yet
+
+	// get existing logins telemetry
+	telemetry := model.Metric(db, model.UserLogins)
+	// if any logins were already recorded, set logins value incremented by 1
+	if telemetry.MetricValue != "" {
+		n, err := strconv.Atoi(telemetry.MetricValue)
+		if err == nil {
+			loginsCount = strconv.Itoa(n + 1)
+		}
+	}
+	// store new logins count
+	model.SetMetric(db, model.UserLogins, loginsCount, "")
 }
 
 func PublishToSegment(db *gorm.DB) {

--- a/server/handler/login.go
+++ b/server/handler/login.go
@@ -16,7 +16,7 @@ type loginData struct {
 
 func GetLoginHandler() HandleFuncWithDB {
 	// initialization of the expected credentials
-	userName := "admin"
+	const userName = "admin"
 	userPassword := config.GetEnvironment().PASSWORD
 
 	return func(db *gorm.DB, w http.ResponseWriter, r *http.Request) {

--- a/server/handler/login.go
+++ b/server/handler/login.go
@@ -3,6 +3,10 @@ package handler
 import (
 	"encoding/json"
 	"net/http"
+	"server/config"
+	"server/engine"
+
+	"gorm.io/gorm"
 )
 
 type loginData struct {
@@ -10,8 +14,12 @@ type loginData struct {
 	Password string `json:"pwd"`
 }
 
-func GetLoginHandler(userName, userPassword string) http.HandlerFunc {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+func GetLoginHandler() HandleFuncWithDB {
+	// initialization of the expected credentials
+	userName := "admin"
+	userPassword := config.GetEnvironment().PASSWORD
+
+	return func(db *gorm.DB, w http.ResponseWriter, r *http.Request) {
 		sessionHelper, err := getSessionHelper()
 		if err != nil {
 			respondError(w, http.StatusInternalServerError, err.Error())
@@ -32,9 +40,11 @@ func GetLoginHandler(userName, userPassword string) http.HandlerFunc {
 				respondError(w, http.StatusInternalServerError, "Could not setup session")
 			}
 			respondJSON(w, http.StatusOK, map[string]string{"status": "success"})
+			// update metrics because user attempted logging in with correct credentials
+			engine.UpdateLogInMetrics(db)
 			return
 		}
 
 		respondError(w, http.StatusUnauthorized, "Invalid user id or password")
-	})
+	}
 }

--- a/server/model/enum.go
+++ b/server/model/enum.go
@@ -26,6 +26,7 @@ const (
 	DeployStatus  DeploymentMetric = "deploystatus"
 	Errors        DeploymentMetric = "errors"
 	Retries       DeploymentMetric = "retries"
+	UserLogins    DeploymentMetric = "userlogins"
 )
 
 type TelemetryStatus string


### PR DESCRIPTION
Added `userlogins` count to the metrics collected by the deployment driver.
Refactored the login handler to allow calling the telemetry code after successful login.