### PR TITLE
AAP-16351 Add console log to fileshare

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ ADD ["nginx", "/etc/nginx/"]
 ADD ["start.sh", "entry.sh", "build/server", "./"]
 ADD ["build/public", "/var/www/aapinstaller/public"]
 
-RUN chmod +x ./acme.sh ./server && chmod +x ./start.sh && chmod +x ./entry.sh
+RUN chmod +x ./acme.sh ./server ./start.sh ./entry.sh
 
 VOLUME [ "/installerstore" ]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,11 +14,11 @@ RUN yum -y --repo ubi-9-appstream-rpms install socat && \
   echo "ACME=${ACME_RELEASE_TAG}" >> versions && echo "DRIVER=${DRIVER_RELEASE_TAG}" >> versions
 
 ADD ["nginx", "/etc/nginx/"]
-ADD ["start.sh", "build/server", "./"]
+ADD ["start.sh", "entry.sh", "build/server", "./"]
 ADD ["build/public", "/var/www/aapinstaller/public"]
 
-RUN chmod +x ./acme.sh ./server && chmod +x ./start.sh
+RUN chmod +x ./acme.sh ./server && chmod +x ./start.sh && chmod +x ./entry.sh
 
 VOLUME [ "/installerstore" ]
 
-ENTRYPOINT ["./start.sh"]
+ENTRYPOINT ["./entry.sh"]

--- a/entry.sh
+++ b/entry.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+# Start up and tee console output to log
+./start.sh 2>&1 | tee -a ${BASE_PATH}/console.log


### PR DESCRIPTION
Addition addition for "bubbling up errors from deployment driver".  The engine.log contains stdout from the engine, but not script output, no stderr output.  This console.log contains both.

A small change to pass in BASE_PATH from aap-azurerm is required as well.