### PR TITLE
Add API for fetching number of entitlements or error message

### DIFF
--- a/server/api/installer.go
+++ b/server/api/installer.go
@@ -82,6 +82,7 @@ func (a *Installer) setRouters() {
 	a.Post("/cancelAllSteps", handler.EnsureAuthenticated(a.WrapHandlerWithDBAndEngine(handler.CancelAllSteps)))
 	a.Post("/deleteContainer", handler.EnsureAuthenticated(a.WrapHandlerWithDB(handler.DeleteContainer)))
 	a.Post("/terminate", handler.EnsureAuthenticated(a.WrapHandlerWithDB(handler.Terminate)))
+	a.Get("/azmarketplaceentitlementscount", handler.EnsureAuthenticated(a.WrapHandlerWithDB(handler.GetNumOfAzureMarketplaceEntitlements)))
 }
 
 func (a *Installer) Get(path string, f func(w http.ResponseWriter, r *http.Request)) {

--- a/server/handler/entitlement.go
+++ b/server/handler/entitlement.go
@@ -1,0 +1,33 @@
+package handler
+
+import (
+	"net/http"
+	"server/model"
+
+	"gorm.io/gorm"
+)
+
+type EntitlementsCount struct {
+	Count int64  `json:"count"`
+	Error string `json:"error"`
+}
+
+func GetNumOfAzureMarketplaceEntitlements(db *gorm.DB, w http.ResponseWriter, r *http.Request) {
+	var entitlements []model.AzureMarketplaceEntitlement
+	if tx := db.Model(&model.AzureMarketplaceEntitlement{}).Find(&entitlements); tx.Error != nil {
+		respondError(w, http.StatusInternalServerError, tx.Error.Error())
+		return
+	}
+	// iterate over the entitlements
+	resp := EntitlementsCount{}
+	for _, e := range entitlements {
+		// error message here is from RH API call, we should not make it into our own error, hence 200 response
+		if e.ErrorMessage != "" {
+			resp.Error = e.ErrorMessage
+			resp.Count = 0
+			break
+		}
+		resp.Count = resp.Count + 1
+	}
+	respondJSON(w, http.StatusOK, &resp)
+}


### PR DESCRIPTION
This PR adds an API to be used by the deployment driver UI.
Since there is no need to display any of the entitlement details in the UI, this API is only returning count or an error message if the entitlement could not have been fetched from Red Hat.