### PR TITLE
Fix bug with auto-retry and azure timeout handling

### DIFF
--- a/server/engine/engine.go
+++ b/server/engine/engine.go
@@ -363,7 +363,7 @@ func (engine *Engine) runStep(step model.Step, execution *model.Execution, waitG
 			log.Errorf("Max step execution time reached for step [%s], Canceling.", step.Name)
 			engine.CancelFutureSteps()
 			engine.CancelRunningStep()
-			execution.Status = model.Failed
+			execution.Status = model.PermanentlyFailed
 			execution.Duration = fmt.Sprintf("> %d minutes", config.GetEnvironment().AZURE_DEPLOYMENT_STEP_TIMEOUT_MIN)
 			execution.Error = "Timeout"
 			execution.ErrorDetails = "Azure deployment step did not complete within the maximum allowed time, please re-deploy."

--- a/server/engine/engine.go
+++ b/server/engine/engine.go
@@ -122,7 +122,7 @@ func (engine *Engine) startDeploymentExecutions() {
 			// check all executions for those can be restarted
 			for _, execution := range currentExecutions {
 				// check if step can be restarted
-				if execution != nil && execution.Status != model.Succeeded && execution.Status != model.Canceled {
+				if execution != nil && execution.Status != model.Succeeded && execution.Status != model.Canceled && execution.Status != model.PermanentlyFailed {
 					restartRequired = true
 					engine.startWaitingForRestart(execution, &executionWaitGroup)
 				}


### PR DESCRIPTION
Just needed to switch from Failed to PermanentlyFailed to keep auto-retry from trying to restart the canceled step.