### PR TITLE
Display banner informing users about their SW subscription

### DIFF
--- a/ui/run.py
+++ b/ui/run.py
@@ -148,6 +148,13 @@ steps = """
 ]
 """
 
+entitlementCount = """
+{
+    "count": 0,
+    "error": ""
+}
+"""
+
 api = flask.Flask('installer')
 
 CORS(api)
@@ -160,5 +167,9 @@ def getSteps():
 def postExecution(id):
     print("restarted")
     return "restarted", 200
+
+@api.route('/azmarketplaceentitlementscount', methods=['GET'])
+def getEntitlementsCount():
+    return entitlementCount, 200, {'Content-Type': 'application/json'}
 
 api.run(host='0.0.0.0', port='55080')

--- a/ui/src/app/Deployment/Deployment.tsx
+++ b/ui/src/app/Deployment/Deployment.tsx
@@ -4,12 +4,27 @@ import { DeploymentProgress } from './DeploymentProgress/DeploymentProgress';
 import { getSteps } from '../apis/deployment';
 import { getEntitlementsCount } from '../apis/entitlements';
 import { DeploymentStepData, DeploymentProgressData, EntitlementsCount } from '../apis/types';
+import { RHLoginModal } from './RHLoginModal';
 import { EntitlementsInfo } from './EntitlementsInfo';
+
+const SHOW_RH_LOGIN_SESSION_STORAGE_KEY = "showRHLogin"
 
 export const Deployment = () => {
 
   const [stepsData, setStepsData] = useState<DeploymentStepData[]>()
   const [progressData, setProgressData] = useState<DeploymentProgressData>()
+  const [showRHLogin, setShowRHLogin] = useState<boolean>(()=>{
+    // this function gets initial state value from session storage
+    const storageItem = sessionStorage.getItem(SHOW_RH_LOGIN_SESSION_STORAGE_KEY);
+    if (storageItem === null) {
+      // store initial value of true and return it
+      sessionStorage.setItem(SHOW_RH_LOGIN_SESSION_STORAGE_KEY,String(true));
+      return true;
+    } else {
+      // return stored value
+      return storageItem.toLowerCase() === 'true'
+    }
+  })
   const [entitlementsCount, setEntitlementsCount] = useState<EntitlementsCount>()
 
   const fetchData = async () => {
@@ -41,11 +56,24 @@ export const Deployment = () => {
   }, [])
 
   useEffect(()=>{
+    // only supporting changing the value to false
+    if (showRHLogin === false) {
+      sessionStorage.setItem(SHOW_RH_LOGIN_SESSION_STORAGE_KEY,String(false));
+    }
+  },[showRHLogin])
+
+  const handleRHLoginModalAction = (loginOpened: boolean) => {
+    //place to add more logic if needed
+    setShowRHLogin(false)
+  }
+
+  useEffect(()=>{
     fetchEntitlementsData()
   },[])
 
   return (
     <>
+      { <RHLoginModal isModalShown={showRHLogin} actionHandler={handleRHLoginModalAction}/> }
       {/* TODO Add some place holder for case when data is not available */}
 
       {entitlementsCount && <EntitlementsInfo entitlementsCount={entitlementsCount}></EntitlementsInfo> }

--- a/ui/src/app/Deployment/EntitlementsInfo.css
+++ b/ui/src/app/Deployment/EntitlementsInfo.css
@@ -1,3 +1,7 @@
 .entitlements-info {
 	font-size: 16px;
 }
+
+.entitlements-info div a {
+	padding-left: 0px;
+}

--- a/ui/src/app/Deployment/EntitlementsInfo.css
+++ b/ui/src/app/Deployment/EntitlementsInfo.css
@@ -1,0 +1,3 @@
+.entitlements-info {
+	font-size: 16px;
+}

--- a/ui/src/app/Deployment/EntitlementsInfo.tsx
+++ b/ui/src/app/Deployment/EntitlementsInfo.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import { Alert, AlertVariant, Button, Text, TextVariants } from '@patternfly/react-core';
+import ExternalLinkSquareAltIcon from '@patternfly/react-icons/dist/esm/icons/external-link-square-alt-icon';
+import { EntitlementsCount } from '../apis/types';
+
+import "./EntitlementsInfo.css"
+
+interface IEntitlementsInfoProps {
+	entitlementsCount: EntitlementsCount
+}
+
+const AlertContent = {
+	"existing": {
+		"variant": AlertVariant.info,
+		"title":"You currently have a subscription to Ansible Automation Platform",
+		"content": "To manage or setup new subscription, visit the" // followed by a link
+	},
+	"pending": {
+		"variant": AlertVariant.info,
+		"title": "Your Ansible Automation Platform subscription is pending",
+		"content": "Your subscription is being entitled and deployed, and will be ready for use shortly. " +
+		"In the meantime, you can manage your subscription from the" //followed by a link
+	},
+	"error": {
+		"variant": AlertVariant.danger,
+		"title": "We're temporarily unable to fetch your subscription information",
+		"content": "In the meantime, you can manage your subscription from the" //followed by a link
+	}
+}
+
+export const EntitlementsInfo = ({entitlementsCount}:IEntitlementsInfoProps) => {
+	let alert: any
+
+	if (entitlementsCount.error) {
+		alert = AlertContent.error
+	} else {
+		alert = (entitlementsCount.count > 0) ? AlertContent.existing : AlertContent.pending
+	}
+
+	return(
+		<Alert variant={alert.variant} isInline={true} title={alert.title} className='entitlements-info'>
+			<Text component={TextVariants.p}>{alert.content} <Button variant="link" component="a" isInline
+				icon={<ExternalLinkSquareAltIcon />} iconPosition="right"
+				href="https://console.redhat.com/" target="_blank">Red Hat Hybrid Cloud Console</Button>
+			</Text>
+		</Alert>
+	)
+}

--- a/ui/src/app/Deployment/EntitlementsInfo.tsx
+++ b/ui/src/app/Deployment/EntitlementsInfo.tsx
@@ -13,35 +13,44 @@ const AlertContent = {
 	"existing": {
 		"variant": AlertVariant.info,
 		"title":"You currently have a subscription to Ansible Automation Platform",
-		"content": "To manage or setup new subscription, visit the" // followed by a link
+		"message": "To manage or setup new subscription, visit the", // followed by a link
+		"linkTitle": "Red Hat Hybrid Cloud Console",
+		"linkURL":"https://console.redhat.com/",
+		"linkInLine": true
 	},
 	"pending": {
 		"variant": AlertVariant.info,
 		"title": "Your Ansible Automation Platform subscription is pending",
-		"content": "Your subscription is being entitled and deployed, and will be ready for use shortly. " +
-		"In the meantime, you can manage your subscription from the" //followed by a link
+		"message": "You do not have an Ansible Automation Platform subscription or your subscription is being entitled. " +
+			"Click on the following link to enable your Ansible Automation Platform subscription and to access Red Hat support. This is a required step in order to access the Ansible Automation Platform once it is deployed.", //followed by a link
+		"linkTitle": "Red Hat Hybrid Cloud Console",
+		"linkURL":"https://console.redhat.com/?azure-ansible-activation",
+		"linkInLine": false
 	},
 	"error": {
 		"variant": AlertVariant.danger,
 		"title": "We're temporarily unable to fetch your subscription information",
-		"content": "In the meantime, you can manage your subscription from the" //followed by a link
+		"message": "Click on the following link to enable your Ansible Automation Platform subscription and to access Red Hat support. This is a required step in order to access the Ansible Automation Platform once it is deployed.", //followed by a link
+		"linkTitle": "Red Hat Hybrid Cloud Console",
+		"linkURL":"https://console.redhat.com/",
+		"linkInLine": false
 	}
 }
 
 export const EntitlementsInfo = ({entitlementsCount}:IEntitlementsInfoProps) => {
-	let alert: any
+	let alertContent: any
 
 	if (entitlementsCount.error) {
-		alert = AlertContent.error
+		alertContent = AlertContent.error
 	} else {
-		alert = (entitlementsCount.count > 0) ? AlertContent.existing : AlertContent.pending
+		alertContent = (entitlementsCount.count > 0) ? AlertContent.existing : AlertContent.pending
 	}
 
 	return(
-		<Alert variant={alert.variant} isInline={true} title={alert.title} className='entitlements-info'>
-			<Text component={TextVariants.p}>{alert.content} <Button variant="link" component="a" isInline
+		<Alert variant={alertContent.variant} isInline={true} title={alertContent.title} className='entitlements-info'>
+			<Text component={TextVariants.p}>{alertContent.message} {!alertContent.linkInLine && <br/>}<Button variant="link" component="a" isInline={alertContent.linkInLine}
 				icon={<ExternalLinkSquareAltIcon />} iconPosition="right"
-				href="https://console.redhat.com/" target="_blank">Red Hat Hybrid Cloud Console</Button>
+				href={alertContent.linkURL} target="_blank">{alertContent.linkTitle}</Button>
 			</Text>
 		</Alert>
 	)

--- a/ui/src/app/Deployment/__tests__/EntitlementsInfo.test.tsx
+++ b/ui/src/app/Deployment/__tests__/EntitlementsInfo.test.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { EntitlementsCount } from '../../apis/types';
+import { EntitlementsInfo } from '../EntitlementsInfo';
+
+test("Subscriptions pending", () => {
+	const noEntitlements:EntitlementsCount = {
+		count: 0,
+		error: ""
+	}
+	render(<EntitlementsInfo entitlementsCount={noEntitlements}></EntitlementsInfo>)
+	const alertTitle = screen.getByText("Your Ansible Automation Platform subscription is pending")
+	const alertContent = screen.getByText(/Your subscription is being entitled and deployed,.+/i)
+	expect(alertTitle).toBeInTheDocument()
+	expect(alertTitle).toBeVisible()
+	expect(alertContent).toBeInTheDocument()
+	expect(alertContent).toBeVisible()
+})
+
+test("Several subscriptions", () => {
+	const noEntitlements:EntitlementsCount = {
+		count: 3,
+		error: ""
+	}
+	render(<EntitlementsInfo entitlementsCount={noEntitlements}></EntitlementsInfo>)
+	const alertTitle = screen.getByText("You currently have a subscription to Ansible Automation Platform")
+	const alertContent = screen.getByText(/To manage or setup new subscription, .+/i)
+	expect(alertTitle).toBeInTheDocument()
+	expect(alertTitle).toBeVisible()
+	expect(alertContent).toBeInTheDocument()
+	expect(alertContent).toBeVisible()
+})
+
+test("Coudln't fetch subscriptions", () => {
+	const noEntitlements:EntitlementsCount = {
+		count: 0,
+		error: "Something odd happened"
+	}
+	render(<EntitlementsInfo entitlementsCount={noEntitlements}></EntitlementsInfo>)
+	const alertTitle = screen.getByText("We're temporarily unable to fetch your subscription information")
+	const alertContent = screen.getByText(/In the meantime, you can manage your subscription.+/i)
+	expect(alertTitle).toBeInTheDocument()
+	expect(alertTitle).toBeVisible()
+	expect(alertContent).toBeInTheDocument()
+	expect(alertContent).toBeVisible()
+})

--- a/ui/src/app/Deployment/__tests__/EntitlementsInfo.test.tsx
+++ b/ui/src/app/Deployment/__tests__/EntitlementsInfo.test.tsx
@@ -10,7 +10,7 @@ test("Subscriptions pending", () => {
 	}
 	render(<EntitlementsInfo entitlementsCount={noEntitlements}></EntitlementsInfo>)
 	const alertTitle = screen.getByText("Your Ansible Automation Platform subscription is pending")
-	const alertContent = screen.getByText(/Your subscription is being entitled and deployed,.+/i)
+	const alertContent = screen.getByText(/You do not have an Ansible Automation Platform subscription or your subscription is being entitled\..+/i)
 	expect(alertTitle).toBeInTheDocument()
 	expect(alertTitle).toBeVisible()
 	expect(alertContent).toBeInTheDocument()
@@ -38,7 +38,7 @@ test("Coudln't fetch subscriptions", () => {
 	}
 	render(<EntitlementsInfo entitlementsCount={noEntitlements}></EntitlementsInfo>)
 	const alertTitle = screen.getByText("We're temporarily unable to fetch your subscription information")
-	const alertContent = screen.getByText(/In the meantime, you can manage your subscription.+/i)
+	const alertContent = screen.getByText(/Click on the following link to enable your Ansible Automation Platform subscription and to access Red Hat support\..+/i)
 	expect(alertTitle).toBeInTheDocument()
 	expect(alertTitle).toBeVisible()
 	expect(alertContent).toBeInTheDocument()

--- a/ui/src/app/apis/entitlements.tsx
+++ b/ui/src/app/apis/entitlements.tsx
@@ -1,0 +1,16 @@
+import { EntitlementsCount } from "./types";
+
+const baseURI = "/api"
+
+export function getEntitlementsCount(): Promise<EntitlementsCount> {
+	return fetch(`${baseURI}/azmarketplaceentitlementscount`)
+		.then((resp) => {
+			if (resp.ok) {
+				return resp.json()
+			}
+			throw new Error(`Unexpected response with status code: ${resp.status}`)
+		})
+		.then((data) => {
+			return new EntitlementsCount(data)
+		})
+}

--- a/ui/src/app/apis/types.tsx
+++ b/ui/src/app/apis/types.tsx
@@ -1,3 +1,5 @@
+import { type } from "os"
+
 export enum StepStatuses {
 	PENDING,
 	STARTED,
@@ -120,6 +122,24 @@ export class DeploymentData {
 			this.progress = new DeploymentProgressData(this.steps)
 		} else {
 			this.progress = new DeploymentProgressData()
+		}
+	}
+}
+
+export class EntitlementsCount {
+	count:number = 0
+	error:string = ""
+	constructor(entitlementCount) {
+		if (entitlementCount) {
+			if ('count' in entitlementCount && typeof entitlementCount.count === "number") {
+				this.count = entitlementCount.count
+			}
+			if ('error' in entitlementCount && typeof entitlementCount.error === "string") {
+				this.error = entitlementCount.error
+				if (this.error.length > 0 ){
+					this.count = 0
+				}
+			}
 		}
 	}
 }

--- a/ui/src/app/apis/types.tsx
+++ b/ui/src/app/apis/types.tsx
@@ -1,5 +1,3 @@
-import { type } from "os"
-
 export enum StepStatuses {
 	PENDING,
 	STARTED,


### PR DESCRIPTION
This PR removes the pop-up modal shown to the users when they first log in to the deployment driver and replaces it with a permanent alert/banner across the top of the UI.
Based on number of SW subscriptions, the user will see different text in the banner however in each different banner the user is always presented with a link to the RH console.

Jira item: <https://issues.redhat.com/browse/AAP-15157>

## Screenshots
Below are screenshots of the possible cases. The screenshots were updated to show state with latest commit.:

###  No SW subscription yet (probably the most common case)
![Screenshot from 2023-11-16 12-27-21](https://github.com/ansible/azure-aap-deployment-driver/assets/93541722/8d67b455-15c1-4f37-abd9-9cef543dd320)


### Existing SW subscription
![Screenshot from 2023-11-16 12-27-52](https://github.com/ansible/azure-aap-deployment-driver/assets/93541722/cd022237-48ff-409c-ad7e-d84f0d9d57e0)


### Error scenario (when the RH API does not respond)
![Screenshot from 2023-11-16 12-28-23](https://github.com/ansible/azure-aap-deployment-driver/assets/93541722/f7bcf5c0-1dec-41ac-89de-bb28b06f2215)


