### PR TITLE
Check for env variable instead of secret

### DIFF
--- a/.github/workflows/code_analysis_ui.yml
+++ b/.github/workflows/code_analysis_ui.yml
@@ -20,10 +20,10 @@ jobs:
           cd ui
           make test-with-coverage
       - name: Run SonarCloud Scan
-        if: ${{ secrets.SONARCLOUD_PROJECT_TOKEN }}
         uses: sonarsource/sonarcloud-github-action@master
-        with:
-          projectBaseDir: ui
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONARCLOUD_PROJECT_TOKEN }}
+        if: ${{ env.SONAR_TOKEN }}
+        with:
+          projectBaseDir: ui


### PR DESCRIPTION
Github workflow does not support checking for secrets in the `if` condition so this PR changes the condition to check for the env variable instead.