### PR TITLE
Move sonarcloud analysis to separate project

### DIFF
--- a/.github/workflows/code_analysis_ui.yml
+++ b/.github/workflows/code_analysis_ui.yml
@@ -6,6 +6,7 @@ on:
     paths: # Only applicable if any UI code was changed
       - 'ui/**'
   pull_request:
+    types: [opened, synchronize, reopened]
     branches:
       - main
     paths: # Only applicable if any UI code was changed
@@ -15,15 +16,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
       - name: Run make in ui directory
         run: |
           cd ui
           make test-with-coverage
       - name: Run SonarCloud Scan
-        uses: sonarsource/sonarcloud-github-action@master
+        uses: SonarSource/sonarcloud-github-action@master
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SONAR_TOKEN: ${{ secrets.SONARCLOUD_PROJECT_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONARCLOUD_UI_PROJECT_TOKEN }}
         if: ${{ env.SONAR_TOKEN }}
         with:
           projectBaseDir: ui

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -9216,20 +9216,6 @@
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
       "dev": true
     },
-    "node_modules/fsevents": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
-      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
-      "hasInstallScript": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
-    },
     "node_modules/function-bind": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",

--- a/ui/sonar-project.properties
+++ b/ui/sonar-project.properties
@@ -1,6 +1,5 @@
-sonar.projectKey=aoc-aap-test-installer
+sonar.projectKey=aoc-aap-installer-ui
 sonar.organization=ansible
-sonar.projectName="Ansible on Clouds Installer"
 sonar.projectBaseDir=.
 sonar.sources=src/
 sonar.exclusions=**/*.test.tsx


### PR DESCRIPTION
SonarCloud does not seem to handle two different programming languages in one repo and monorepos are only supported on Azure. Hence this PR is moving the code analysis into separate SonarCloud project.