### PR TITLE
Add API for engine configuration

### DIFF
--- a/server/api/installer.go
+++ b/server/api/installer.go
@@ -74,6 +74,7 @@ func (a *Installer) configureSessionHelper() {
 
 func (a *Installer) setRouters() {
 	a.Get("/status", a.WrapHandlerWithDB(handler.Status))
+	a.Get("/engineconfiguration", handler.EnsureAuthenticated(handler.GetEngineConfiguration))
 	a.Get("/authtype", handler.AuthType)
 	a.Get("/authcheck", handler.GetAuthCheckHandler(false))
 	a.Get("/authchecksso", handler.GetAuthCheckHandler(true))

--- a/server/config/environment.go
+++ b/server/config/environment.go
@@ -23,11 +23,11 @@ type envVars struct {
 	ENGINE_END_WAIT                     int64
 	ENGINE_MAX_RUNTIME                  int64
 	ENGINE_RETRY_WAIT                   int64
-	EXECUTION_MAX_RETRY                 int
+	EXECUTION_MAX_RETRY                 int64
 	AZURE_POLLING_FREQ_SECONDS          int
-	AZURE_DEPLOYMENT_STEP_TIMEOUT_MIN   int
+	AZURE_DEPLOYMENT_STEP_TIMEOUT       int64
 	AUTO_RETRY                          bool
-	AUTO_RETRY_DELAY                    int
+	AUTO_RETRY_DELAY                    int64
 	AUTH_TYPE                           string
 	SESSION_COOKIE_NAME                 string
 	SESSION_COOKIE_PATH                 string
@@ -73,7 +73,7 @@ func GetEnvironment() envVars {
 	environment.DB_REL_PATH = "installer.db"    // on top of BASE_PATH
 	environment.TEMPLATE_REL_PATH = "templates" // on top of BASE_PATH
 	environment.AZURE_POLLING_FREQ_SECONDS = 5
-	environment.AZURE_DEPLOYMENT_STEP_TIMEOUT_MIN = 30
+	environment.AZURE_DEPLOYMENT_STEP_TIMEOUT = 1800 // 30 min timeout for any one azure deployment
 	environment.AUTO_RETRY = false
 	environment.AUTO_RETRY_DELAY = 60 // Retry after 60 seconds if AUTO_RETRY set
 	environment.SESSION_COOKIE_NAME = "madd_session"
@@ -176,11 +176,11 @@ func GetEnvironment() envVars {
 		environment.AZURE_LOGIN_RETRIES = int(azureLoginRetries)
 	}
 
-	azureStepTimeoutMin, err := strconv.ParseInt(env.Get("AZURE_DEPLOYMENT_STEP_TIMEOUT_MIN", "0"), 10, 32)
+	azureStepTimeout, err := strconv.ParseInt(env.Get("AZURE_DEPLOYMENT_STEP_TIMEOUT", "0"), 10, 32)
 	if err != nil {
-		log.Warnf("AZURE_DEPLOYMENT_STEP_TIMEOUT_MIN environment variable is not a number, will use default of %d", environment.AZURE_DEPLOYMENT_STEP_TIMEOUT_MIN)
-	} else if azureStepTimeoutMin != 0 {
-		environment.AZURE_DEPLOYMENT_STEP_TIMEOUT_MIN = int(azureStepTimeoutMin)
+		log.Warnf("AZURE_DEPLOYMENT_STEP_TIMEOUT_MIN environment variable is not a number, will use default of %d", environment.AZURE_DEPLOYMENT_STEP_TIMEOUT)
+	} else if azureStepTimeout != 0 {
+		environment.AZURE_DEPLOYMENT_STEP_TIMEOUT = int64(azureStepTimeout)
 	}
 
 	basePath := env.Get("BASE_PATH")
@@ -264,7 +264,7 @@ func GetEnvironment() envVars {
 	if err != nil {
 		log.Warnf("EXECUTION_MAX_RETRY environment variable is not set or is not a number, will use default: %d", environment.EXECUTION_MAX_RETRY)
 	} else {
-		environment.EXECUTION_MAX_RETRY = int(executionMaxRetry)
+		environment.EXECUTION_MAX_RETRY = executionMaxRetry
 	}
 
 	// using empty string as default to force error condition and use of default when env variable not set
@@ -290,9 +290,9 @@ func GetEnvironment() envVars {
 		if autoRetryDelay > int64(environment.ENGINE_RETRY_WAIT) {
 			maxAutoRetryDelay := environment.ENGINE_RETRY_WAIT / 2
 			log.Warnf("AUTO_RETRY_DELAY cannot exceed ENGINE_RETRY_WAIT, setting to: %d", maxAutoRetryDelay)
-			environment.AUTO_RETRY_DELAY = int(maxAutoRetryDelay)
+			environment.AUTO_RETRY_DELAY = int64(maxAutoRetryDelay)
 		} else {
-			environment.AUTO_RETRY_DELAY = int(autoRetryDelay)
+			environment.AUTO_RETRY_DELAY = int64(autoRetryDelay)
 		}
 	}
 

--- a/server/config/environment.go
+++ b/server/config/environment.go
@@ -23,7 +23,7 @@ type envVars struct {
 	ENGINE_END_WAIT                     int64
 	ENGINE_MAX_RUNTIME                  int64
 	ENGINE_RETRY_WAIT                   int64
-	EXECUTION_MAX_RETRY                 int64
+	EXECUTION_MAX_RETRY                 int
 	AZURE_POLLING_FREQ_SECONDS          int
 	AZURE_DEPLOYMENT_STEP_TIMEOUT       int64
 	AUTO_RETRY                          bool
@@ -264,7 +264,7 @@ func GetEnvironment() envVars {
 	if err != nil {
 		log.Warnf("EXECUTION_MAX_RETRY environment variable is not set or is not a number, will use default: %d", environment.EXECUTION_MAX_RETRY)
 	} else {
-		environment.EXECUTION_MAX_RETRY = executionMaxRetry
+		environment.EXECUTION_MAX_RETRY = int(executionMaxRetry)
 	}
 
 	// using empty string as default to force error condition and use of default when env variable not set

--- a/server/engine/datatypes.go
+++ b/server/engine/datatypes.go
@@ -15,6 +15,6 @@ type Engine struct {
 	mainOutputs          *model.Output
 	done                 chan struct{}
 	status               *model.Status
-	maxExecutionRestarts int
+	maxExecutionRestarts int64
 	deploymentsClient    *armresources.DeploymentsClient
 }

--- a/server/engine/datatypes.go
+++ b/server/engine/datatypes.go
@@ -15,6 +15,6 @@ type Engine struct {
 	mainOutputs          *model.Output
 	done                 chan struct{}
 	status               *model.Status
-	maxExecutionRestarts int64
+	maxExecutionRestarts int
 	deploymentsClient    *armresources.DeploymentsClient
 }

--- a/server/engine/engine.go
+++ b/server/engine/engine.go
@@ -354,7 +354,7 @@ func (engine *Engine) runStep(step model.Step, execution *model.Execution, waitG
 	}
 
 	// Finish deployment and wait for result (with timeout)
-	timeout := time.Duration(config.GetEnvironment().AZURE_DEPLOYMENT_STEP_TIMEOUT_MIN) * time.Minute
+	timeout := time.Duration(config.GetEnvironment().AZURE_DEPLOYMENT_STEP_TIMEOUT) * time.Second
 	ctxWithTimeout, cancel := context.WithTimeout(engine.context, timeout)
 	defer cancel()
 
@@ -371,7 +371,7 @@ func (engine *Engine) runStep(step model.Step, execution *model.Execution, waitG
 			engine.CancelFutureSteps()
 			engine.CancelRunningStep()
 			execution.Status = model.PermanentlyFailed
-			execution.Duration = fmt.Sprintf("> %d minutes", config.GetEnvironment().AZURE_DEPLOYMENT_STEP_TIMEOUT_MIN)
+			execution.Duration = fmt.Sprintf("> %d minutes", int(timeout.Minutes()))
 			execution.Error = "Timeout"
 			execution.ErrorDetails = "Azure deployment step did not complete within the maximum allowed time, please re-deploy."
 			engine.database.Instance.Save(&execution)

--- a/server/handler/handler_test.go
+++ b/server/handler/handler_test.go
@@ -317,7 +317,7 @@ func TestSessionHelper(t *testing.T) {
 	assert.Equal(t, http.StatusOK, rec.Result().StatusCode, "Expected OK from auth with cookie.")
 }
 
-func TestTimeouts(t *testing.T) {
+func TestEngineConfiguration(t *testing.T) {
 	timeouts := model.EngineConfiguration{}
 	resp := testHttpRoute(t, http.MethodGet, "/engineconfiguration", nil)
 	assert.Equal(t, http.StatusOK, resp.Result().StatusCode)

--- a/server/handler/handler_test.go
+++ b/server/handler/handler_test.go
@@ -317,6 +317,21 @@ func TestSessionHelper(t *testing.T) {
 	assert.Equal(t, http.StatusOK, rec.Result().StatusCode, "Expected OK from auth with cookie.")
 }
 
+func TestTimeouts(t *testing.T) {
+	timeouts := model.EngineConfiguration{}
+	resp := testHttpRoute(t, http.MethodGet, "/engineconfiguration", nil)
+	assert.Equal(t, http.StatusOK, resp.Result().StatusCode)
+	if err := json.Unmarshal(resp.Body.Bytes(), &timeouts); err != nil {
+		t.Error(err.Error())
+	}
+	assert.Equal(t, config.GetEnvironment().AZURE_DEPLOYMENT_STEP_TIMEOUT, timeouts.StepDeploymentTimeout)
+	assert.Equal(t, config.GetEnvironment().ENGINE_END_WAIT, timeouts.EngineExitDelay)
+	assert.Equal(t, config.GetEnvironment().ENGINE_MAX_RUNTIME, timeouts.OverallTimeout)
+	assert.Equal(t, config.GetEnvironment().EXECUTION_MAX_RETRY, timeouts.StepMaxRetries)
+	assert.Equal(t, config.GetEnvironment().AUTO_RETRY_DELAY, timeouts.AutoRetryDelay)
+	assert.Equal(t, config.GetEnvironment().ENGINE_RETRY_WAIT, timeouts.StepRestartTimeout)
+}
+
 // TestMain wraps the tests.  Setup is done before the call to m.Run() and any
 // needed teardown after that.
 func TestMain(m *testing.M) {

--- a/server/handler/status.go
+++ b/server/handler/status.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/http"
 
+	"server/config"
 	"server/model"
 
 	"gorm.io/gorm"
@@ -39,6 +40,18 @@ func Status(db *gorm.DB, w http.ResponseWriter, r *http.Request) {
 		}
 	}
 	respondJSON(w, http.StatusOK, map[string]string{"status": status.toString()})
+}
+
+func GetEngineConfiguration(w http.ResponseWriter, r *http.Request) {
+	timeouts := model.EngineConfiguration{
+		StepRestartTimeout:    config.GetEnvironment().ENGINE_RETRY_WAIT,
+		OverallTimeout:        config.GetEnvironment().ENGINE_MAX_RUNTIME,
+		EngineExitDelay:       config.GetEnvironment().ENGINE_END_WAIT,
+		AutoRetryDelay:        config.GetEnvironment().AUTO_RETRY_DELAY,
+		StepDeploymentTimeout: config.GetEnvironment().AZURE_DEPLOYMENT_STEP_TIMEOUT,
+		StepMaxRetries:        config.GetEnvironment().EXECUTION_MAX_RETRY,
+	}
+	respondJSON(w, http.StatusOK, timeouts)
 }
 
 func getLatestExecution(db *gorm.DB, step model.Step) model.Execution {

--- a/server/model/model.go
+++ b/server/model/model.go
@@ -64,7 +64,7 @@ type EngineConfiguration struct {
 	EngineExitDelay       int64 `json:"engineExitDelaySec"`
 	AutoRetryDelay        int64 `json:"autoRetryDelaySec"`
 	StepDeploymentTimeout int64 `json:"stepDeploymentTimeoutSec"`
-	StepMaxRetries        int64 `json:"stepMaxRetries"`
+	StepMaxRetries        int   `json:"stepMaxRetries"`
 }
 
 type SessionConfig struct {

--- a/server/model/model.go
+++ b/server/model/model.go
@@ -58,6 +58,15 @@ type Status struct {
 	FirstStart        time.Time
 }
 
+type EngineConfiguration struct {
+	StepRestartTimeout    int64 `json:"stepRestartTimeoutSec"`
+	OverallTimeout        int64 `json:"overallTimeoutSec"`
+	EngineExitDelay       int64 `json:"engineExitDelaySec"`
+	AutoRetryDelay        int64 `json:"autoRetryDelaySec"`
+	StepDeploymentTimeout int64 `json:"stepDeploymentTimeoutSec"`
+	StepMaxRetries        int64 `json:"stepMaxRetries"`
+}
+
 type SessionConfig struct {
 	BaseModel
 	SessionAuthKey []byte


### PR DESCRIPTION
Support for AAP-10647 - Show timeouts and limits in UI

Exposes timeouts and max counts via new API on /engineconfiguration.