### PR TITLE
Add unit test to verify logo image

### DIFF
--- a/ui/src/app/AppLayout/__tests__/AppLayout.test.tsx
+++ b/ui/src/app/AppLayout/__tests__/AppLayout.test.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { RouterProvider, createMemoryRouter } from 'react-router-dom';
+import { render, screen } from '@testing-library/react';
+import { AppLayout } from '../AppLayout';
+
+describe('AppLayout', ()=>{
+	it('renders Page with proper AAP logo', ()=> {
+		const routes = [
+			{
+				element: <AppLayout navigation={[]} />,
+				children: [
+					{
+						path: "/",
+						element: <></>
+					}
+				]
+			}
+		]
+
+		const router = createMemoryRouter(routes, {
+			initialEntries: ["/"],
+		});
+		// what's passed to the render() is the same what's done index.tsx file
+		render(<RouterProvider router={router} />);
+
+		//screen.debug();
+
+		const logo = screen.getByAltText("Red Hat Ansible Automation Platform Logo")
+		expect(logo).toBeInTheDocument()
+		expect(logo).toBeVisible()
+		expect(logo).toHaveAttribute("src","Technology_icon-Red_Hat-Ansible_Automation_Platform-Standard-RGB.svg")
+	})
+})

--- a/ui/src/app/AppLayout/__tests__/AppLayout.test.tsx
+++ b/ui/src/app/AppLayout/__tests__/AppLayout.test.tsx
@@ -23,8 +23,6 @@ describe('AppLayout', ()=>{
 		// what's passed to the render() is the same what's done index.tsx file
 		render(<RouterProvider router={router} />);
 
-		//screen.debug();
-
 		const logo = screen.getByAltText("Red Hat Ansible Automation Platform Logo")
 		expect(logo).toBeInTheDocument()
 		expect(logo).toBeVisible()

--- a/ui/src/app/AppLayout/__tests__/PlainLayout.test.tsx
+++ b/ui/src/app/AppLayout/__tests__/PlainLayout.test.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { PlainLayout } from '../PlainLayout';
+
+describe('AppLayout', ()=>{
+	it('renders Page with proper AAP logo', ()=> {
+		render(<PlainLayout />)
+
+		const logo = screen.getByAltText("Red Hat Ansible Automation Platform Logo")
+		expect(logo).toBeInTheDocument()
+		expect(logo).toBeVisible()
+		expect(logo).toHaveAttribute("src","Technology_icon-Red_Hat-Ansible_Automation_Platform-Standard-RGB.svg")
+	})
+})

--- a/ui/src/app/AppLayout/__tests__/PlainLayout.test.tsx
+++ b/ui/src/app/AppLayout/__tests__/PlainLayout.test.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { render, screen } from '@testing-library/react';
 import { PlainLayout } from '../PlainLayout';
 
-describe('AppLayout', ()=>{
+describe('PlainLayout', ()=>{
 	it('renders Page with proper AAP logo', ()=> {
 		render(<PlainLayout />)
 


### PR DESCRIPTION
This PR adds unit tests for the AAP logo used in the layout components.