### PR TITLE
AAP-19126 - Fix showing RH login dialog

### DIFF
--- a/nginx/sites-enabled/aapinstaller.http_and_https.conf.disabled
+++ b/nginx/sites-enabled/aapinstaller.http_and_https.conf.disabled
@@ -51,46 +51,33 @@ server {
         return 302 /;
     }
 
-    # location specific to login(exactly matching the /), does not check for authenticated
-    location = / {
-        index  index.html;
+    # location specific to login(exactly matching the /login), does not check for authenticated
+    location = /login {
+        try_files /index.html =404;
+    }
+
+    # location specific to login(exactly matching the /rhlogin), does not check for authenticated
+    location = /rhlogin {
         try_files /index.html =404;
     }
 
     # main location for any remaining URI, checks for valid session
-    location = /welcome {
-        auth_request /authcheck;
-
-        # serve what ever was requested, or index.html or 404 error
-        try_files $uri $uri/ /index.html =404;
-    }
-
-    # main location for any remaining URI, checks for valid session
     location / {
-        auth_request /authchecksso;
+        auth_request        /authstatus;
+        auth_request_set    $auth_session_creds $upstream_http_x_session_creds;
+        auth_request_set    $auth_session_sso   $upstream_http_x_session_sso;
 
         # serve what ever was requested, or index.html or 404 error
         try_files $uri $uri/ /index.html =404;
     }
 
     # location for performing check of the authentication status, returns 401 if not authenticated
-    location = /authcheck {
+    location = /authstatus {
         internal;
-        proxy_pass              http://127.0.0.1:9090/authcheck;
+        proxy_pass              http://127.0.0.1:9090/authstatus;
         include                 nginxconfig.io/proxy.conf;
         proxy_pass_request_body off;
         proxy_set_header        Content-Length "";
-
-    }
-
-    # location for performing check of the authentication and SSO status, returns 401 if not authenticated
-    location = /authchecksso {
-        internal;
-        proxy_pass              http://127.0.0.1:9090/authchecksso;
-        include                 nginxconfig.io/proxy.conf;
-        proxy_pass_request_body off;
-        proxy_set_header        Content-Length "";
-
     }
 
     # make error 401 passed as is (=) to the named location @error401
@@ -98,11 +85,14 @@ server {
 
     # error page location
     location @error401 {
-        # TODO Add more sophisticated handling to differentiate between the
-        #   authentication checks performed and respond with different redirects
-
-        return 302 /;
+        if ($auth_session_creds = false) {
+            return 302 /login;
+        }
+        if ($auth_session_sso = false) {
+            return 302 /rhlogin;
+        }
     }
+
 
     # additional config
     include nginxconfig.io/general.conf;

--- a/nginx/sites-enabled/aapinstaller.http_https_local_dev.conf
+++ b/nginx/sites-enabled/aapinstaller.http_https_local_dev.conf
@@ -51,46 +51,33 @@ server {
         return 302 /;
     }
 
-    # location specific to login(exactly matching the /), does not check for authenticated
-    location = / {
-        index  index.html;
+    # location specific to login(exactly matching the /login), does not check for authenticated
+    location = /login {
+        try_files /index.html =404;
+    }
+
+    # location specific to login(exactly matching the /rhlogin), does not check for authenticated
+    location = /rhlogin {
         try_files /index.html =404;
     }
 
     # main location for any remaining URI, checks for valid session
-    location = /welcome {
-        auth_request /authcheck;
-
-        # serve what ever was requested, or index.html or 404 error
-        try_files $uri $uri/ /index.html =404;
-    }
-
-    # main location for any remaining URI, checks for valid session
     location / {
-        auth_request /authchecksso;
+        auth_request        /authstatus;
+        auth_request_set    $auth_session_creds $upstream_http_x_session_creds;
+        auth_request_set    $auth_session_sso   $upstream_http_x_session_sso;
 
         # serve what ever was requested, or index.html or 404 error
         try_files $uri $uri/ /index.html =404;
     }
 
     # location for performing check of the authentication status, returns 401 if not authenticated
-    location = /authcheck {
+    location = /authstatus {
         internal;
-        proxy_pass              http://127.0.0.1:9090/authcheck;
+        proxy_pass              http://127.0.0.1:9090/authstatus;
         include                 nginxconfig.io/proxy.conf;
         proxy_pass_request_body off;
         proxy_set_header        Content-Length "";
-
-    }
-
-    # location for performing check of the authentication and SSO status, returns 401 if not authenticated
-    location = /authchecksso {
-        internal;
-        proxy_pass              http://127.0.0.1:9090/authchecksso;
-        include                 nginxconfig.io/proxy.conf;
-        proxy_pass_request_body off;
-        proxy_set_header        Content-Length "";
-
     }
 
     # make error 401 passed as is (=) to the named location @error401
@@ -98,10 +85,12 @@ server {
 
     # error page location
     location @error401 {
-        # TODO Add more sophisticated handling to differentiate between the
-        #   authentication checks performed and respond with different redirects
-
-        return 302 /;
+        if ($auth_session_creds = false) {
+            return 302 /login;
+        }
+        if ($auth_session_sso = false) {
+            return 302 /rhlogin;
+        }
     }
 
     # additional config

--- a/scripts/run_nginx_https_local_dev.sh
+++ b/scripts/run_nginx_https_local_dev.sh
@@ -40,7 +40,7 @@ if [ ! -f "nginx/dhparam.pem" ]; then
 fi
 
 echo "Building the container image for nginx..."
-docker build -f Dockerfile.nginx-only.local_dev -t deploymentdrivernginx:latest .
+DOCKER_BUILDKIT=1 docker build -f Dockerfile.nginx-only.local_dev -t deploymentdrivernginx:latest .
 
 echo "Starting the container for nginx... You can exit it with: ctrl-c"
 docker run -ti --name nginx --rm \

--- a/server/api/installer.go
+++ b/server/api/installer.go
@@ -76,8 +76,7 @@ func (a *Installer) setRouters() {
 	a.Get("/status", a.WrapHandlerWithDB(handler.Status))
 	a.Get("/engineconfiguration", handler.EnsureAuthenticated(handler.GetEngineConfiguration))
 	a.Get("/authtype", handler.AuthType)
-	a.Get("/authcheck", handler.GetAuthCheckHandler(false))
-	a.Get("/authchecksso", handler.GetAuthCheckHandler(true))
+	a.Get("/authstatus", handler.AuthStatusHandler)
 	a.Post("/login", a.WrapHandlerWithDB(handler.CredentialsHandler{}.GetLoginHandler())) // GetLoginHandler() must be executed to do its initialization
 	a.Post("/logout", handler.EnsureAuthenticated(handler.Logout))
 	a.Get("/step", handler.EnsureAuthenticated(a.WrapHandlerWithDB(handler.GetAllSteps)))

--- a/server/handler/ssoHandler.go
+++ b/server/handler/ssoHandler.go
@@ -85,7 +85,7 @@ func (s *SsoHandler) SsoRedirect(db *gorm.DB, w http.ResponseWriter, r *http.Req
 		return
 	}
 	log.Trace("Redirecting to deployment driver home.")
-	http.Redirect(w, r, fmt.Sprintf("https://%s/deployment", config.GetEnvironment().INSTALLER_DOMAIN_NAME), http.StatusTemporaryRedirect)
+	http.Redirect(w, r, fmt.Sprintf("https://%s/", config.GetEnvironment().INSTALLER_DOMAIN_NAME), http.StatusTemporaryRedirect)
 }
 
 func (s *SsoHandler) rollState() error {

--- a/ui/src/app/Login/LoginForm.tsx
+++ b/ui/src/app/Login/LoginForm.tsx
@@ -21,7 +21,7 @@ export function FormLogin() {
         setShowHelperText(true);
       } else {
         setIsValidPassword(true)
-        navigate('/welcome');
+        navigate('/rhlogin');
       }
     } catch (err: any) {
       console.log('Got exception from logging in.', err);

--- a/ui/src/app/__tests__/app.test.tsx
+++ b/ui/src/app/__tests__/app.test.tsx
@@ -5,27 +5,23 @@ import App from '..';
 import appRoutes from '../app.routes';
 
 describe('Main app', ()=>{
-  it('initially renders login form', () => {
-    render(<App />);
-    verifyInitialLoginForm()
-  });
 
-  it('route / renders login form', ()=>{
-    navigateTo('/')
+  it('route /login renders login form', ()=>{
+    navigateTo('/login')
     verifyInitialLoginForm()
   })
 
-  it('route /welcome renders deployment component with SSO login dialog over it', ()=>{
-    navigateTo('/welcome')
+  it('route /rhlogin renders deployment component with SSO login dialog over it', ()=>{
+    navigateTo('/rhlogin')
     const dialog = screen.getByRole('dialog')
     expect(dialog).toBeVisible()
     const login = screen.getByRole('link', {name:'Log in with Red Hat account'})
     expect(login).toBeVisible()
   })
 
-  it('route /deployment renders deployment component without the SSO login dialog', ()=>{
+  it('route / renders deployment component without the SSO login dialog', ()=>{
     //const user = userEvent.setup()
-    navigateTo('/deployment')
+    navigateTo('/')
     const dialog = screen.queryByRole('dialog')
     expect(dialog).toBeNull()
   })

--- a/ui/src/app/app.navigation.tsx
+++ b/ui/src/app/app.navigation.tsx
@@ -1,6 +1,6 @@
 const appNavigation = [
   {
-    path: "/deployment",
+    path: "/",
     label: "Deployment"
   },
   {

--- a/ui/src/app/app.routes.tsx
+++ b/ui/src/app/app.routes.tsx
@@ -11,7 +11,7 @@ const appRoutes = [
 		element: <PlainLayout />,
 		children: [
 			{
-				path: "/",
+				path: "/login",
 				element: <Login />
 			}
 		]
@@ -20,7 +20,7 @@ const appRoutes = [
 		element: <AppLayout navigation={appNavigation} />,
 		children: [
 			{
-				path: "/welcome",
+				path: "/rhlogin",
 				element: <Deployment showLoginDialog={true} />
 			}
 		]
@@ -29,7 +29,7 @@ const appRoutes = [
 		element: <AppLayout navigation={appNavigation} />,
 		children: [
 			{
-				path: "/deployment",
+				path: "/",
 				element: <Deployment showLoginDialog={false}/>
 			},
 			{


### PR DESCRIPTION
This PR changes the UI routes to avoid issue with RH login dialog showing up on page reload.
With these changes, the / path shows the main application view with deployment. However, to get to that, user has to do the two logins. First one with admin and the password and then the RH login (SSO).
After the login flow is done, reloading the page does not bring up the RH login dialog.