### PR TITLE
AAP-19533 Fix rendering of the Red Hat Login dialog title

### DIFF
--- a/ui/src/app/Deployment/RHLoginModal.css
+++ b/ui/src/app/Deployment/RHLoginModal.css
@@ -1,0 +1,3 @@
+h1.pf-c-title span.pf-c-icon {
+  margin-right: (--pf-c-modal-box__title-icon--MarginRight)
+}

--- a/ui/src/app/Deployment/RHLoginModal.tsx
+++ b/ui/src/app/Deployment/RHLoginModal.tsx
@@ -15,17 +15,17 @@ const DialogHeader = <Title headingLevel="h1" size={TitleSizes['2xl']}>
 export const RHLoginModal = ({isModalShown}: IRHLoginProps) => {
 	return (
 		<Modal
-				header={DialogHeader}
-        isOpen={isModalShown}
-        showClose={false}
-				variant={ModalVariant.medium}
-				actions={[
-					// TODO Set the URL in href below programmatically
-          <Button
-					key="login" variant="primary"
-					icon={<ExternalLinkSquareAltIcon />} iconPosition="right"
-					component="a" href="/sso" target="_self">Log in with Red Hat account</Button>,
-        ]}
+			header={DialogHeader}
+			isOpen={isModalShown}
+			showClose={false}
+			variant={ModalVariant.medium}
+			actions={[
+				// TODO Set the URL in href below programmatically
+				<Button
+				key="login" variant="primary"
+				icon={<ExternalLinkSquareAltIcon />} iconPosition="right"
+				component="a" href="/sso" target="_self">Log in with Red Hat account</Button>,
+			]}
       ><p>Your Ansible Automation Platform deployment is underway.</p>
 			<br /><p>To use Ansible Automation Platform on Azure, you MUST have a valid subscription for Ansible Automation Platform in your Red Hat account.</p>
 			<br />

--- a/ui/src/app/Deployment/RHLoginModal.tsx
+++ b/ui/src/app/Deployment/RHLoginModal.tsx
@@ -1,16 +1,21 @@
 import React from 'react';
-import { Button, Modal, ModalVariant } from '@patternfly/react-core';
+import { Button, Icon, Modal, ModalVariant, Title, TitleSizes } from '@patternfly/react-core';
 import ExternalLinkSquareAltIcon from '@patternfly/react-icons/dist/esm/icons/external-link-square-alt-icon';
+import ExclamationTriangleIcon from '@patternfly/react-icons/dist/esm/icons/exclamation-triangle-icon';
+import './RHLoginModal.css';
 
 interface IRHLoginProps {
 	isModalShown: boolean
 }
 
+const DialogHeader = <Title headingLevel="h1" size={TitleSizes['2xl']}>
+	<Icon status="warning" isInline><ExclamationTriangleIcon /></Icon>A valid subscription for Ansible Automation Platform in your Red Hat account is required
+</Title>;
+
 export const RHLoginModal = ({isModalShown}: IRHLoginProps) => {
 	return (
 		<Modal
-        title="A valid subscription for Ansible Automation Platform in your Red Hat account is required"
-				titleIconVariant="warning"
+				header={DialogHeader}
         isOpen={isModalShown}
         showClose={false}
 				variant={ModalVariant.medium}


### PR DESCRIPTION
With this PR the dialog title is not going to be cut off (with ellipsis added).
It also fixes formatting of the code in the component.

![image](https://github.com/ansible/azure-aap-deployment-driver/assets/93541722/88d2f2b9-2d4f-460c-8015-cb0250f660c1)
