### PR TITLE
Fix order of logging messages

### DIFF
--- a/server/handler/authenticator.go
+++ b/server/handler/authenticator.go
@@ -21,7 +21,7 @@ type Authenticator struct {
 type AuthenticatorConfig struct {
 	Context      context.Context
 	SsoEndpoint  string
-	RedirecUrl   string
+	RedirectUrl  string
 	ClientId     string
 	ClientSecret string
 	Scopes       []string
@@ -37,7 +37,7 @@ func NewAuthenticator(authConfig AuthenticatorConfig) (*Authenticator, error) {
 	oauth2Config := oauth2.Config{
 		ClientID:     authConfig.ClientId,
 		ClientSecret: authConfig.ClientSecret,
-		RedirectURL:  authConfig.RedirecUrl,
+		RedirectURL:  authConfig.RedirectUrl,
 		Endpoint:     provider.Endpoint(),
 		Scopes:       authConfig.Scopes,
 	}

--- a/server/handler/handler_test.go
+++ b/server/handler/handler_test.go
@@ -196,7 +196,7 @@ func TestSsoHandler(t *testing.T) {
 	authCfg := handler.AuthenticatorConfig{
 		Context:      context.Background(),
 		SsoEndpoint:  ssoServer.Issuer(),
-		RedirecUrl:   redirServer.URL,
+		RedirectUrl:  redirServer.URL,
 		ClientId:     ssoServer.ClientID,
 		ClientSecret: ssoServer.ClientSecret,
 		Scopes:       []string{oidc.ScopeOpenID, "profile", "email"},

--- a/server/sso/acsclient.go
+++ b/server/sso/acsclient.go
@@ -66,6 +66,7 @@ func GetAcsClient(ctx context.Context) *AcsClient {
 			ClientSecret: config.GetEnvironment().SSO_CLIENT_SECRET,
 			Context:      ctx,
 		}
+		log.Trace("Initialized new instance of SSO client.")
 	})
 	log.Trace("Getting SSO client API access token.")
 	token, err := acsClient.getToken()
@@ -74,7 +75,7 @@ func GetAcsClient(ctx context.Context) *AcsClient {
 		return nil
 	}
 	acsClient.Token = token
-	log.Trace("Initialized SSO client.")
+	log.Trace("Got SSO client.")
 	return acsClient
 }
 

--- a/server/sso/ssoManager.go
+++ b/server/sso/ssoManager.go
@@ -76,7 +76,7 @@ func (s *SsoManager) initialize() error {
 		Scopes:       []string{oidc.ScopeOpenID, "profile", "email", ID_SCOPE},
 		ClientId:     credentials.ClientId,
 		ClientSecret: credentials.ClientSecret,
-		RedirecUrl:   handler.GetRedirectUrl(),
+		RedirectUrl:  handler.GetRedirectUrl(),
 		SsoEndpoint:  config.GetEnvironment().SSO_ENDPOINT,
 		Audience:     ID_SCOPE,
 	}
@@ -90,12 +90,12 @@ func (s *SsoManager) initialize() error {
 }
 
 func (s *SsoManager) DeleteAcsClient() {
-	log.Trace("Deleting SSO client.")
 	acsClient := GetAcsClient(s.Context)
 	credentials, _ := model.GetSsoStore().GetSsoClientCredentials()
+	log.Trace("Deleting SSO client.")
 	_, err := acsClient.DeleteACSClient(credentials.ClientId)
 	if err != nil {
-		log.Errorf("failure to delete ACS client: %v", err)
+		log.Errorf("failed to delete ACS client: %v", err)
 	}
 }
 


### PR DESCRIPTION
This PR fixes a minor issue with order of trace messages and also one typo in struct field.
Before this PR the engine would log following messages at the end, when engine is exiting:
```
time="2024-01-16 22:47:10" level=trace msg="Deleting SSO client." func="server/sso.(*SsoManager).DeleteAcsClient" file="ssoManager.go:93"
time="2024-01-16 22:47:10" level=trace msg="Getting SSO client API access token." func=server/sso.GetAcsClient file="acsclient.go:70"
time="2024-01-16 22:47:10" level=trace msg="Initialized SSO client." func=server/sso.GetAcsClient file="acsclient.go:77"
```
These look to come out in wrong order but they aren't. By moving them into better locations in the logging output looks better:
```
time="2024-01-18 00:51:10" level=trace msg="Getting SSO client API access token." func=server/sso.GetAcsClient file="acsclient.go:71"
time="2024-01-18 00:51:10" level=trace msg="Got SSO client." func=server/sso.GetAcsClient file="acsclient.go:78"
time="2024-01-18 00:51:10" level=trace msg="Deleting SSO client." func="server/sso.(*SsoManager).DeleteAcsClient" file="ssoManager.go:95"
```