### PR TITLE
AAP-9450 Present useful message when engine is dead

### DIFF
--- a/ui/requirements.txt
+++ b/ui/requirements.txt
@@ -1,2 +1,3 @@
 Flask==2.2.2
 flask_cors==3.0.10
+Werkzeug==2.2.2

--- a/ui/src/app/Login/FixedUsernameLoginForm.tsx
+++ b/ui/src/app/Login/FixedUsernameLoginForm.tsx
@@ -32,6 +32,8 @@ export interface FixedUsernameLoginFormProps extends Omit<React.HTMLProps<HTMLFo
   usernameValue?: string;
   /** Lock username text input */
   usernameDisabled?: boolean;
+  /** Lock password text input */
+  passwordDisabled?: boolean;
   /** Function that handles the onChange event for the username */
   onChangeUsername?: (value: string, event: React.FormEvent<HTMLInputElement>) => void;
   /** Flag indicating if the username is valid */
@@ -73,6 +75,7 @@ export const FixedUsernameLoginForm: React.FunctionComponent<FixedUsernameLoginF
   usernameLabel = 'Username',
   usernameValue = '',
   usernameDisabled = false,
+  passwordDisabled = false,
   onChangeUsername = () => undefined as any,
   isValidUsername = true,
   passwordLabel = 'Password',
@@ -101,6 +104,7 @@ export const FixedUsernameLoginForm: React.FunctionComponent<FixedUsernameLoginF
       validated={isValidPassword ? ValidatedOptions.default : ValidatedOptions.error}
       value={passwordValue}
       onChange={onChangePassword}
+      isDisabled={passwordDisabled}
     />
   );
 

--- a/ui/src/app/Login/LoginForm.tsx
+++ b/ui/src/app/Login/LoginForm.tsx
@@ -16,7 +16,7 @@ export function FormLogin() {
     try {
       const response = await login({ uid: uid, pwd: pwd });
       if ('unavailable' === response.status) {
-        setLoginMessage('Your deployment was not successful, please return to Microsoft Azure Portal and redeploy.')
+	setLoginMessage('Sorry, we are having trouble signing you in as your deployment may have failed. Please return to Microsoft Azure Portal and attempt to redeploy Ansible Automation Platform.')
         setShowHelperText(true)
         setIsLoginButtonDisabled(true)
         setPasswordDisabled(true)

--- a/ui/src/app/Login/LoginForm.tsx
+++ b/ui/src/app/Login/LoginForm.tsx
@@ -16,7 +16,7 @@ export function FormLogin() {
     try {
       const response = await login({ uid: uid, pwd: pwd });
       if ('unavailable' == response.status) {
-        setLoginMessage('Deployment Driver unavailable, please re-deploy.')
+        setLoginMessage('Deployment Engine unavailable, please re-deploy.')
         setIsValidPassword(false)
         setShowHelperText(true)
       }

--- a/ui/src/app/Login/LoginForm.tsx
+++ b/ui/src/app/Login/LoginForm.tsx
@@ -17,7 +17,6 @@ export function FormLogin() {
       const response = await login({ uid: uid, pwd: pwd });
       if ('unavailable' === response.status) {
         setLoginMessage('Your deployment was not successful, please return to Microsoft Azure Portal and redeploy.')
-        setIsValidPassword(false)
         setShowHelperText(true)
         setIsLoginButtonDisabled(true)
         setPasswordDisabled(true)

--- a/ui/src/app/Login/LoginForm.tsx
+++ b/ui/src/app/Login/LoginForm.tsx
@@ -15,7 +15,12 @@ export function FormLogin() {
   async function loginHandler(uid: string, pwd: string) {
     try {
       const response = await login({ uid: uid, pwd: pwd });
-      if ('error' in response && response.error) {
+      if ('unavailable' == response.status) {
+        setLoginMessage('Deployment Driver unavailable, please re-deploy.')
+        setIsValidPassword(false)
+        setShowHelperText(true)
+      }
+      else if ('error' in response && response.error) {
         setLoginMessage('Incorrect Password');
         setIsValidPassword(false)
         setShowHelperText(true);

--- a/ui/src/app/Login/LoginForm.tsx
+++ b/ui/src/app/Login/LoginForm.tsx
@@ -15,7 +15,7 @@ export function FormLogin() {
   async function loginHandler(uid: string, pwd: string) {
     try {
       const response = await login({ uid: uid, pwd: pwd });
-      if ('unavailable' == response.status) {
+      if ('unavailable' === response.status) {
         setLoginMessage('Deployment Engine unavailable, please re-deploy.')
         setIsValidPassword(false)
         setShowHelperText(true)

--- a/ui/src/app/Login/LoginForm.tsx
+++ b/ui/src/app/Login/LoginForm.tsx
@@ -16,9 +16,11 @@ export function FormLogin() {
     try {
       const response = await login({ uid: uid, pwd: pwd });
       if ('unavailable' === response.status) {
-        setLoginMessage('Deployment Engine unavailable, please re-deploy.')
+        setLoginMessage('Your deployment was not successful, please return to Microsoft Azure Portal and redeploy.')
         setIsValidPassword(false)
         setShowHelperText(true)
+        setIsLoginButtonDisabled(true)
+        setPasswordDisabled(true)
       }
       else if ('error' in response && response.error) {
         setLoginMessage('Incorrect Password');
@@ -42,6 +44,8 @@ export function FormLogin() {
   const [showHelperText, setShowHelperText] = React.useState(false);
   const [password, setPassword] = React.useState('');
   const [isValidPassword, setIsValidPassword] = React.useState(true);
+  const [isLoginButtonDisabled, setIsLoginButtonDisabled] = React.useState(false);
+  const [passwordDisabled, setPasswordDisabled] = React.useState(false);
 
   const handlePasswordChange = (value: string) => {
     setPassword(value);
@@ -67,6 +71,8 @@ export function FormLogin() {
       onLoginButtonClick={onLoginButtonClick}
       loginButtonLabel="Log in"
       usernameDisabled={true}
+      isLoginButtonDisabled={isLoginButtonDisabled}
+      passwordDisabled={passwordDisabled}
     />
   );
 }

--- a/ui/src/app/apis/auth.tsx
+++ b/ui/src/app/apis/auth.tsx
@@ -15,7 +15,7 @@ export function login(loginData: ILoginData) :Promise<IAuthResponse>  {
 		else if (resp.status === 401){
 			return ({status:"", error:`Incorrect Password`} as IAuthResponse);
 		}
-		else if (resp.status == 502){
+		else if (resp.status === 502){
 			return ({status:"unavailable", error:`Deployment Driver server unavailable`} as IAuthResponse);
 		}
 		return ({status:"", error:`Unexpected response with status code: ${resp.status}`} as IAuthResponse);

--- a/ui/src/app/apis/auth.tsx
+++ b/ui/src/app/apis/auth.tsx
@@ -15,6 +15,9 @@ export function login(loginData: ILoginData) :Promise<IAuthResponse>  {
 		else if (resp.status === 401){
 			return ({status:"", error:`Incorrect Password`} as IAuthResponse);
 		}
+		else if (resp.status == 502){
+			return ({status:"unavailable", error:`Deployment Driver server unavailable`} as IAuthResponse);
+		}
 		return ({status:"", error:`Unexpected response with status code: ${resp.status}`} as IAuthResponse);
 	}).catch((err) =>{
 		return ({status:"", error: err.message} as IAuthResponse);


### PR DESCRIPTION
# Description
This PR adds a message "Deployment Engine unavailable, please re-deploy" when the login form receives a 502, which happens when the backend is timed out.  This is a partial fix, since it doesn't take care of an already logged in screen.  Maybe we should add a message on the UI that  shows itself when the backend goes away too.


## Commit message reminder

Commit messages are important because they will be used to build list of items included in Errata when the deployment driver container image is built and QE will use that list to figure out what to test before the image is published.

- For user facing features or fixes make sure Jira item number `AAP-nnnnn` is included in the commit message(s)
- For other changes, like unit tests or code refactoring, do not include Jira item numbers

## PR task checklist
- [x] I have used appropriate commit messages based on section above
- [x] I have performed a self-review of my code
- [x] I have followed code style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added thorough tests
- [x] I have had a successful deployment with the changes in this PR

## Jira
This PR is for JIRA item: <https://issues.redhat.com/browse/AAP-9450>

## Testing
### Steps to test
1. Pull down the PR
2. Start deployment
3. Wait for engine to end naturally or connect to container and kill it ('server' process).
4. Attempt to log in, see new message.

### Expected result
With the changes in this PR you will see a new message when attempting to log in when engine is down.

