### PR TITLE
AAP-20519 Extend waiting time for deployment failures

### DIFF
--- a/server/model/model.go
+++ b/server/model/model.go
@@ -52,10 +52,11 @@ type Execution struct {
 
 type Status struct {
 	BaseModel
-	TemplatesLoaded   bool
-	MainOutputsLoaded bool
-	IsFatalState      bool
-	FirstStart        time.Time
+	TemplatesLoaded     bool
+	MainOutputsLoaded   bool
+	IsFatalState        bool
+	FirstStart          time.Time
+	DeploymentSucceeded bool
 }
 
 type EngineConfiguration struct {


### PR DESCRIPTION
# Description
This PR just extends the wait-until-self-death time period in the case that the deployment fails, so that customers have a while longer to see that their deployment failed.


## PR task checklist
- [x] I have used appropriate commit messages based on section above
- [x] I have performed a self-review of my code
- [x] I have followed code style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added thorough tests
- [x] I have had a successful deployment with the changes in this PR

## Jira
This PR is for JIRA item: <https://issues.redhat.com/browse/AAP-20519>

## Testing
### Steps to test
1. Pull down the PR
2. Deploy (but cause failure in a step)
3. See that the deployment hangs around longer (total of 2 hours from start)

