### PR TITLE
Move to new sonarcloud project

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,4 +67,4 @@ For more details on working with development containers, please see [https://cod
 ## SonarQube
 
 Sonar analysis is performed by Github Actions on the code repository for this
-project.  Results available at [sonarcloud.io](https://sonarcloud.io/project/overview?id=aoc-aap-test-installer)
+project.  Results available at [sonarcloud.io](https://sonarcloud.io/project/overview?id=ansible_azure-aap-deployment-driver) (server) and [sonarcloud.io](https://sonarcloud.io/project/overview?id=aoc-aap-installer-ui) (UI)

--- a/server/sonar-project.properties
+++ b/server/sonar-project.properties
@@ -1,6 +1,5 @@
-sonar.projectKey=aoc-aap-test-installer
+sonar.projectKey=ansible_azure-aap-deployment-driver
 sonar.organization=ansible
-sonar.projectName="Ansible on Clouds Installer"
 sonar.projectBaseDir=.
 sonar.sources=.
 sonar.go.coverage.reportPaths=coverage.txt


### PR DESCRIPTION
New sonarcloud bound project for server.  UI will stay the same.  There are two separate projects in order to measure code coverage for server and UI separately.