### PR TITLE
Add workflow_dispatch to both code analysis workflows to run manually

### DIFF
--- a/.github/workflows/code_analysis_server.yml
+++ b/.github/workflows/code_analysis_server.yml
@@ -12,6 +12,7 @@ on:
     paths: # Only applicable if any go code was changed
       - 'server/**/*.go'
       - 'server/*.go'
+  workflow_dispatch:
 jobs:
   Build-Test-and-Analyze-Server:
     runs-on: ubuntu-latest

--- a/.github/workflows/code_analysis_ui.yml
+++ b/.github/workflows/code_analysis_ui.yml
@@ -11,6 +11,7 @@ on:
       - main
     paths: # Only applicable if any UI code was changed
       - 'ui/**'
+  workflow_dispatch:
 jobs:
   Build-Test-and-Analyze-UI:
     runs-on: ubuntu-latest


### PR DESCRIPTION
# Description
We need to be able to manually execute the sonarqube scan tool on the main branch when necessary, and this small change should allow us to do that.

## Links
https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#workflow_dispatch