### PR TITLE
Fix UI test failure in the cvp pipeline

### DIFF
--- a/test/ui/cypress/support/auth.js
+++ b/test/ui/cypress/support/auth.js
@@ -25,15 +25,17 @@ Cypress.Commands.add('loginWithRHAccount', () => {
     // 'Log in with Red Hat account using user name and password
     cy.origin(Cypress.env('RH_SSO_URL'), () => {
       cy.on('uncaught:exception', (err, runnable) => {
-        return false;
-      });
-      cy.get('input#username-verification.pf-c-form-control').type(Cypress.env('RH_ACCOUNT_USERNAME'))
-      cy.get('#login-show-step2')
+        // returning false here prevents Cypress
+        // inside the cy.origin() method from failing the test
+        return false
+      })
+      cy.get('#username-verification', {timeout: 6000}).type(Cypress.env('RH_ACCOUNT_USERNAME'), {force: true})
+      cy.get('#login-show-step2', {timeout: 6000})
         .should('have.text', 'Next')
-        .click()
-    cy.get('input#password.pf-c-form-control').type(Cypress.env('RH_ACCOUNT_PASSWORD'))
+        .click({force: true})
+    cy.get('#password', {timeout: 6000}).type(Cypress.env('RH_ACCOUNT_PASSWORD'), {force: true})
     cy.get('button#rh-password-verification-submit-button.pf-c-button')
-      .click()
+      .click({force: true})
     })
 
     // Check that the user is redirected to the Deployment Engine UI


### PR DESCRIPTION
# Description
With the change in the [PR!132](https://github.com/ansible/azure-aap-deployment-driver/pull/132), I could get all the deployment engine UI test cases passed when I ran them from my local machine. But when using the deployment driver ui CVP pipeline to run the tests, there were still some test cases failed due to the timeout & ui element invisible issue when the automation tried to use RH SSO to do the login.
This PR is to fix RH SSO login issue in the automation when using the Jenkins pipeline to run the deployment driver UI tests.

## Commit message reminder

Commit messages are important because they will be used to build list of items included in Errata when the deployment driver container image is built and QE will use that list to figure out what to test before the image is published.

- For user facing features or fixes make sure Jira item number `AAP-nnnnn` is included in the commit message(s)
- For other changes, like unit tests or code refactoring, do not include Jira item numbers

## PR task checklist
<!-- Mark tasks done by putting x inside [ ]. If any task in the checklist does not apply, mark the task done AND surround the text with ~ ~ (tilda) to strike it out -->
- [x] I have used appropriate commit messages based on section above
- [x] I have performed a self-review of my code
- [x] I have followed code style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added thorough tests
- [ ] I have had a successful deployment with the changes in this PR

## Jira
https://issues.redhat.com/browse/AAP-41601

## Testing
Verified that the deployment Engine UI Cypress automation could pass with the latest deployment driver build of `aoc-azure-aap-installer-container-1.0.24-6` and AAP 2.5 by using the deployment driver ui CVP pipeline.
https://jenkins-csb-aap-main.dno.corp.redhat.com/job/AAPQA/job/AoC/job/Managed_Azure/job/Sandbox/job/qiwang/job/CVP/job/deployment_driver_ui/19/consoleFull
```
18:38:19  TASK [aapqa.aoc_azure.deployment_driver : Print test results to console] *******
18:38:19  ok: [installer-0] => 
18:38:19    msg:
18:38:19    - 'It looks like this is your first time using Cypress: 13.6.6'
18:38:19    - ''
18:38:19    - '[STARTED] Task without title.'
18:38:19    - '[TITLE]  Verified Cypress!       /home/azureuser/.cache/Cypress/13.6.6/Cypress'
18:38:19    - '[SUCCESS]  Verified Cypress!       /home/azureuser/.cache/Cypress/13.6.6/Cypress'
18:38:19    - ''
18:38:19    - Opening Cypress...
18:38:19    - ''
18:38:19    - ================================================================================
18:38:19    - ''
18:38:19    - '  (Run Starting)'
18:38:19    - ''
18:38:19    - '  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐'
18:38:19    - '  │ Cypress:        13.6.6                                                                         │'
18:38:19    - '  │ Browser:        Electron 118 (headless)                                                        │'
18:38:19    - '  │ Node Version:   v18.20.6 (/usr/bin/node)                                                       │'
18:38:19    - '  │ Specs:          1 found (deployment_driver.cy.js)                                              │'
18:38:19    - '  │ Searched:       cypress/e2e/**/*.cy.{js,jsx,ts,tsx}                                            │'
18:38:19    - '  └────────────────────────────────────────────────────────────────────────────────────────────────┘'
18:38:19    - ''
18:38:19    - ''
18:38:19    - ────────────────────────────────────────────────────────────────────────────────────────────────────
18:38:19    - '                                                                                                    '
18:38:19    - '  Running:  deployment_driver.cy.js                                                         (1 of 1)'
18:38:19    - ''
18:38:19    - ''
18:38:19    - '  Deployment driver web UI'
18:38:19    - '    ✓ main view contains label, steps and status area with cancel button (11614ms)'
18:38:19    - '    ✓ left navigation has expected navigation links (6276ms)'
18:38:19    - '    ✓ list of deployment steps contains expected steps (6017ms)'
18:38:19    - '    ✓ clicking cancel button brings up a dialog that can be closed (6249ms)'
18:38:19    - '    ✓ Checking the Deployment Engine UI logout (6188ms)'
18:38:19    - ''
18:38:19    - ''
18:38:19    - '  5 passing (40s)'
18:38:19    - ''
18:38:19    - ''
18:38:19    - '  (Results)'
18:38:19    - ''
18:38:19    - '  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐'
18:38:19    - '  │ Tests:        5                                                                                │'
18:38:19    - '  │ Passing:      5                                                                                │'
18:38:19    - '  │ Failing:      0                                                                                │'
18:38:19    - '  │ Pending:      0                                                                                │'
18:38:19    - '  │ Skipped:      0                                                                                │'
18:38:19    - '  │ Screenshots:  0                                                                                │'
18:38:19    - '  │ Video:        false                                                                            │'
18:38:19    - '  │ Duration:     40 seconds                                                                       │'
18:38:19    - '  │ Spec Ran:     deployment_driver.cy.js                                                          │'
18:38:19    - '  └────────────────────────────────────────────────────────────────────────────────────────────────┘'
18:38:19    - ''
18:38:19    - ''
18:38:19    - ================================================================================
18:38:19    - ''
18:38:19    - '  (Run Finished)'
18:38:19    - ''
18:38:19    - ''
18:38:19    - '       Spec                                              Tests  Passing  Failing  Pending  Skipped  '
18:38:19    - '  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐'
18:38:19    - '  │ ✔  deployment_driver.cy.js                  00:40        5        5        -        -        - │'
18:38:19    - '  └────────────────────────────────────────────────────────────────────────────────────────────────┘'
18:38:19    - '    ✔  All specs passed!                        00:40        5        5        -        -        -  '
18:38:19  
18:38:19  PLAY RECAP *********************************************************************
18:38:19  installer-0                : ok=16   changed=11   unreachable=0    failed=0    skipped=1    rescued=0    ignored=0
```

### Steps to test
1. Pull down the PR
2. ...
3. ...

### Expected result
The Deployment Engine UI Cypress automation can pass with the latest deployment driver build of `aoc-azure-aap-installer-container-1.0.24-6` and AAP 2.5 by using the deployment driver ui CVP pipeline, which was updated via https://issues.redhat.com/browse/AAP-40962.

### Screenshots / Console output / Logs
See my test results above.
