### PR TITLE
Increase timeout and logging info for deployment engine driver

### DIFF
--- a/nginx/sites-enabled/aapinstaller.http_only.conf
+++ b/nginx/sites-enabled/aapinstaller.http_only.conf
@@ -6,4 +6,8 @@ server {
         add_header Content-Type text/plain;
         return 200 'OK';
     }
+
+    location = /api/status {
+        proxy_pass http://127.0.0.1:9090/status;
+    }
 }

--- a/server/azure/client.go
+++ b/server/azure/client.go
@@ -86,9 +86,11 @@ func StartDeployARMTemplate(ctx context.Context, client *armresources.Deployment
 
 	opts := armresources.DeploymentsClientBeginCreateOrUpdateOptions{}
 
-	// Restart of interrupted deployment
 	if resumeToken != "" {
+		log.Infof("Resuming interrupted deployment for step [%s]", name)
 		opts.ResumeToken = resumeToken
+	} else {
+		log.Infof("Starting new deployment for step [%s]", name)
 	}
 	deploy, err := client.BeginCreateOrUpdate(
 		ctx,
@@ -104,22 +106,25 @@ func StartDeployARMTemplate(ctx context.Context, client *armresources.Deployment
 		&opts,
 	)
 	if err != nil {
+		log.Errorf("Failed to begin ARM deployment for step [%s]: %v", name, err)
 		return nil, err
 	}
-	log.Tracef("Triggered deployment for [%s] (resume token present: %v)", name, resumeToken != "")
+	log.Infof("ARM deployment started for step [%s]", name)
 	return deploy, err
 }
 
 // Pass the deployment poller from StartDeployARMTemplate to await its completion and result
 // Returns model.DeploymentResult and error if any
 func WaitForDeployARMTemplate(ctx context.Context, name string, deployment *runtime.Poller[armresources.DeploymentsClientCreateOrUpdateResponse]) (*model.DeploymentResult, error) {
-	log.Tracef("Starting polling until deployment of [%s] is done...", name)
+	log.Infof("Waiting for ARM deployment [%s] to complete...", name)
 	resp, err := deployment.PollUntilDone(ctx, &runtime.PollUntilDoneOptions{Frequency: time.Duration(config.GetEnvironment().AZURE_POLLING_FREQ_SECONDS) * time.Second})
 	if err != nil {
+		log.Errorf("ARM deployment [%s] finished with error: %v", name, err)
 		return nil, err
 	}
-	log.Tracef("Finished polling, deployment of [%s] is done.", name)
-	return model.NewDeploymentResult(resp.DeploymentExtended), nil
+	result := model.NewDeploymentResult(resp.DeploymentExtended)
+	log.Infof("ARM deployment [%s] completed with provisioning state: %s", name, result.ProvisioningState)
+	return result, nil
 }
 
 func GetDeployment(ctx context.Context, client *armresources.DeploymentsClient, name string) (*model.DeploymentResult, error) {
@@ -138,10 +143,13 @@ func GetDeployment(ctx context.Context, client *armresources.DeploymentsClient, 
 }
 
 func CancelDeployment(ctx context.Context, client *armresources.DeploymentsClient, name string) error {
+	log.Infof("Issuing cancel request for ARM deployment [%s]", name)
 	_, err := client.Cancel(ctx, config.GetEnvironment().RESOURCE_GROUP_NAME, name, &armresources.DeploymentsClientCancelOptions{})
 	if err != nil {
+		log.Errorf("Cancel request for ARM deployment [%s] failed: %v", name, err)
 		return err
 	}
+	log.Infof("Cancel request for ARM deployment [%s] accepted by Azure", name)
 	return nil
 }
 

--- a/server/config/environment.go
+++ b/server/config/environment.go
@@ -67,7 +67,7 @@ func GetEnvironment() envVars {
 	// setting defaults here
 	environment.ENGINE_END_WAIT = 900     // 15 minutes wait before server exits after its done
 	environment.ENGINE_RETRY_WAIT = 1800  // 30 minutes wait for a step to be restarted
-	environment.ENGINE_MAX_RUNTIME = 7200 // 2 hours max run time for everything (including restarts)
+	environment.ENGINE_MAX_RUNTIME = 10800 // 3 hours max run time for everything (including restarts)
 	environment.EXECUTION_MAX_RETRY = 10  // 10 executions in total allowed
 	environment.BASE_PATH = "/installerstore"
 	environment.DB_REL_PATH = "installer.db"    // on top of BASE_PATH

--- a/server/config/environment.go
+++ b/server/config/environment.go
@@ -73,7 +73,7 @@ func GetEnvironment() envVars {
 	environment.DB_REL_PATH = "installer.db"    // on top of BASE_PATH
 	environment.TEMPLATE_REL_PATH = "templates" // on top of BASE_PATH
 	environment.AZURE_POLLING_FREQ_SECONDS = 5
-	environment.AZURE_DEPLOYMENT_STEP_TIMEOUT = 1800 // 30 min timeout for any one azure deployment
+	environment.AZURE_DEPLOYMENT_STEP_TIMEOUT = 3000 // 50 min timeout for any one azure deployment
 	environment.AUTO_RETRY = false
 	environment.AUTO_RETRY_DELAY = 60 // Retry after 60 seconds if AUTO_RETRY set
 	environment.SESSION_COOKIE_NAME = "madd_session"

--- a/server/engine/engine.go
+++ b/server/engine/engine.go
@@ -361,11 +361,21 @@ func (engine *Engine) runStep(step model.Step, execution *model.Execution, waitG
 		log.Printf("Failed to update execution in DB with resume token: %v", err)
 	}
 
-	// Finish deployment and wait for result (with timeout)
+	// Finish deployment and wait for result (with timeout).
+	// Derive from a deadline-free context so each retry gets the full timeout window,
+	// not just whatever remains on ENGINE_MAX_RUNTIME.
 	timeout := time.Duration(config.GetEnvironment().AZURE_DEPLOYMENT_STEP_TIMEOUT) * time.Second
 	log.Infof("Waiting for step [%s] with timeout of %d minutes", step.Name, int(timeout.Minutes()))
-	ctxWithTimeout, cancel := context.WithTimeout(engine.context, timeout)
+	stepCtx := context.WithoutCancel(engine.context)
+	ctxWithTimeout, cancel := context.WithTimeout(stepCtx, timeout)
 	defer cancel()
+	go func() {
+		select {
+		case <-engine.context.Done():
+			cancel()
+		case <-ctxWithTimeout.Done():
+		}
+	}()
 
 	deployResponse, err := azure.WaitForDeployARMTemplate(ctxWithTimeout, step.Name, deployment)
 	if err != nil {

--- a/server/engine/engine.go
+++ b/server/engine/engine.go
@@ -261,13 +261,13 @@ func (engine *Engine) startWaitingForRestart(execution *model.Execution, waitGro
 
 func (engine *Engine) restartStepAfterDelay(delay time.Duration, execution *model.Execution) *time.Timer {
 	if config.GetEnvironment().AUTO_RETRY {
-		log.Tracef("Starting a timer to automatically restart step after: %s", delay)
+		log.Infof("AUTO_RETRY enabled — scheduling automatic restart of step in %s", delay)
 		return time.AfterFunc(delay, func() {
 			storedExecution := model.Execution{}
 			engine.database.Instance.Last(&storedExecution, model.Execution{StepID: execution.StepID})
 			storedExecution.Status = model.Restart
 			engine.database.Instance.Save(&storedExecution)
-			log.Trace("Automatically marked execution for restart.")
+			log.Infof("Automatically marked step (execution ID %d) for restart", storedExecution.ID)
 		})
 	}
 	return nil
@@ -363,19 +363,18 @@ func (engine *Engine) runStep(step model.Step, execution *model.Execution, waitG
 
 	// Finish deployment and wait for result (with timeout)
 	timeout := time.Duration(config.GetEnvironment().AZURE_DEPLOYMENT_STEP_TIMEOUT) * time.Second
+	log.Infof("Waiting for step [%s] with timeout of %d minutes", step.Name, int(timeout.Minutes()))
 	ctxWithTimeout, cancel := context.WithTimeout(engine.context, timeout)
 	defer cancel()
 
 	deployResponse, err := azure.WaitForDeployARMTemplate(ctxWithTimeout, step.Name, deployment)
 	if err != nil {
 		if errors.Is(err, context.Canceled) {
-			// Parent context canceled, shutdown
-			log.Printf("Completion of step [%s] deployment interrupted by shutdown.", step.Name)
+			log.Infof("Step [%s] interrupted by engine shutdown", step.Name)
 			return
 		}
 		if errors.Is(err, context.DeadlineExceeded) {
-			// Child context timed out
-			log.Errorf("Max step execution time reached for step [%s], Canceling.", step.Name)
+			log.Errorf("Step [%s] exceeded maximum allowed time of %d minutes — canceling running and future steps", step.Name, int(timeout.Minutes()))
 			engine.CancelFutureSteps()
 			engine.CancelRunningStep()
 			execution.Status = model.PermanentlyFailed
@@ -386,10 +385,13 @@ func (engine *Engine) runStep(step model.Step, execution *model.Execution, waitG
 			engine.status.DeploymentSucceeded = false
 			return
 		}
-		log.Printf("Deployment of step [%s] failed: %v", step.Name, err)
+		log.Errorf("Step [%s] failed: %v", step.Name, err)
+		log.Errorf("Step [%s] Azure error details: %s", step.Name, model.GetAzureErrorJSONString(err))
 		failedDeploymentResponse, getDeploymentErr := azure.GetDeployment(engine.context, engine.deploymentsClient, step.Name)
 		if getDeploymentErr != nil {
-			log.Tracef("Unable to get failed deployment details: %v", getDeploymentErr)
+			log.Errorf("Unable to fetch failed deployment details for step [%s]: %v", step.Name, getDeploymentErr)
+		} else if failedDeploymentResponse != nil {
+			log.Infof("Step [%s] provisioning state at failure: %s", step.Name, failedDeploymentResponse.ProvisioningState)
 		}
 		model.UpdateExecution(execution, failedDeploymentResponse, model.GetAzureErrorJSONString(err))
 		engine.database.Instance.Save(&execution)
@@ -407,9 +409,9 @@ func (engine *Engine) runStep(step model.Step, execution *model.Execution, waitG
 func (engine *Engine) CancelFutureSteps() {
 	steps := []model.Step{}
 	engine.database.Instance.Model(&model.Step{}).Preload("Executions").Find(&steps)
-	// first mark all non executing steps as cancelled
 	for _, aStep := range steps {
 		if len(aStep.Executions) == 0 {
+			log.Infof("Marking future step [%s] as canceled (will not run)", aStep.Name)
 			engine.database.Instance.Save(&model.Execution{
 				Status: model.Canceled,
 				StepID: aStep.ID,
@@ -420,13 +422,13 @@ func (engine *Engine) CancelFutureSteps() {
 
 func (engine *Engine) CancelRunningStep() {
 	steps := []model.Step{}
-	engine.database.Instance.Model(&model.Step{}).Preload("Executions").Find(&steps) // find currently running steps and cancel them
+	engine.database.Instance.Model(&model.Step{}).Preload("Executions").Find(&steps)
 	for _, aStep := range steps {
-		// check status of last one, there should not be any steps with no executions
 		if engine.GetLatestExecution(aStep).Status == model.Started {
+			log.Infof("Canceling currently running step [%s]", aStep.Name)
 			err := azure.CancelDeployment(engine.context, engine.deploymentsClient, aStep.Name)
 			if err != nil {
-				log.Errorf("Couldn't cancel deployment: %v", err)
+				log.Errorf("Failed to cancel running step [%s]: %v", aStep.Name, err)
 			}
 		}
 	}

--- a/start.sh
+++ b/start.sh
@@ -74,6 +74,11 @@ test -f /etc/nginx/sites-enabled/aapinstaller.http_and_https.conf.disabled && \
 log "Starting nginx..."
 nginx
 
+# Start the server immediately so /api/status is reachable over HTTP during cert setup
+export SESSION_COOKIE_DOMAIN=${INSTALLER_DOMAIN_NAME}
+./server &
+SERVER_PID=$!
+
 # start generating dhparam file if not generated yet and let it run in background
 DHPARAM_PID=""
 if [ ! -f /installerstore/nginx/dhparam.pem ]; then
@@ -175,12 +180,6 @@ else
   log "Nginx already configured for HTTPS."
 fi
 
-# configure session domain to match installer domain
-export SESSION_COOKIE_DOMAIN=${INSTALLER_DOMAIN_NAME}
-
-./server &
-
-SERVER_PID=$!
 NGINX_PID=$(cat /var/run/nginx.pid)
 
 log "Start-up done, will wait here while nginx is running."


### PR DESCRIPTION
# Description
<!-- Describe the changes introduced in the PR below, include rationale and technical/design decisions -->
This PR adds more logging info for deployments to be able to better troubleshoot issues with deployments during pipeline failures. Also increased the timeout wait to 50mins in order to give ACIs more opportunity to spin up as they tend to fail to spin up during the prepare aap script


<!-- Uncomment following block and add links (surrounded by < and > ) to any resources or documents if those might help explain the PR -->
<!--
## Links
<...>
-->

## Commit message reminder

Commit messages are important because they will be used to build list of items included in Errata when the deployment driver container image is built and QE will use that list to figure out what to test before the image is published.

- For user facing features or fixes make sure Jira item number `AAP-nnnnn` is included in the commit message(s)
- For other changes, like unit tests or code refactoring, do not include Jira item numbers

## PR task checklist
<!-- Mark tasks done by putting x inside [ ]. If any task in the checklist does not apply, mark the task done AND surround the text with ~ ~ (tilda) to strike it out -->
- [x] I have used appropriate commit messages based on section above
- [x] I have performed a self-review of my code
- [x] I have followed code style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added thorough tests
- [x] I have had a successful deployment with the changes in this PR

## Jira
This PR is for JIRA item: https://redhat.atlassian.net/jira/software/c/projects/AAP/boards/1072?search=jef&selectedIssue=AAP-78287


## Testing
<!-- Describe the testing process in set of steps. If testing is not applicable, remove the steps and add a statement explaining why testing isn't applicable. -->
### Steps to test
1. Deploy an instance in AnsibleWorks using the create_marketplace_offering.sh script and use the flag:
```
--deployment-driver-image "quay.io/jemarmol/azure-aap-deployment-driver:timeout-50min"
--engine-template-url "https://rhaapdev.blob.core.windows.net/templates/jeff-timeout-test-sleep.zip" 
```
The `jeff-timeout-test-sleep.zip` template has a sleep for 30 minutes added for the `prepare profile` step in the deployment in order to validate that the timeout at the deployment engine driver level works


### Expected result
<!-- Describe expected results  -->
With the changes in this PR you will see that the timeout for deployment scripts is 50mins

### Screenshots / Console output / Logs
<!-- Add screenshot and/or console output if applicable and uncomment applicable block below -->
Screenshots:
<img width="1379" height="295" alt="Screenshot 2026-06-08 at 10 29 43 PM" src="https://github.com/user-attachments/assets/4c579028-537d-415e-91ac-07709dd94870" />


<!--
Output or logs:
```sh
Raw text goes here
```
-->
